### PR TITLE
feat: improve lock screen with vibrant gradient background

### DIFF
--- a/components/auth-gate.tsx
+++ b/components/auth-gate.tsx
@@ -56,7 +56,7 @@ export function AuthGate({ children }: AuthGateProps) {
 	// Show lock screen
 	return (
 		<View style={{ flex: 1, backgroundColor: theme.background }}>
-			<GradientBackground variant="animated" />
+			<GradientBackground variant="simple" />
 
 			<SafeAreaView style={{ flex: 1 }}>
 				<View


### PR DESCRIPTION
## Summary
- Use the colorful "simple" gradient variant on the lock screen to match the visual style of the onboarding flow
- Changes the lock screen from using a muted animated gradient to the vibrant radial gradient with orange, pink, purple, and blue colors

## Test plan
- [x] Enable local authentication in settings
- [x] Lock the app and verify the lock screen displays vibrant gradient colors matching the onboarding flow

Closes #92