### PR TITLE
fix: update tests to match current implementation

### DIFF
--- a/src/__tests__/actions/ai-chat-model.test.ts
+++ b/src/__tests__/actions/ai-chat-model.test.ts
@@ -128,6 +128,22 @@ const mockWhisperLLMCardsJson = {
 	},
 };
 
+// Mock the constants module to avoid circular dependency issues
+jest.mock("../../actions/ai/constants", () => ({
+	DEFAULT_AI_CHAT_MODEL: {
+		name: "Default Test Model",
+		type: "gguf" as const,
+		sourceUrl: "https://example.com/default-model.gguf",
+		sizeGB: 0.5,
+		parametersB: 0.5,
+		ramGB: 2,
+		systemMessage: {
+			template: "You are a helpful assistant.",
+			defaultTemplateValues: {},
+		},
+	},
+}));
+
 // Mock utility functions
 jest.mock("../../utils/bytes", () => ({
 	bytesToGB: jest.fn((bytes: number) => bytes / (1024 * 1024 * 1024)),

--- a/src/__tests__/actions/chat.test.ts
+++ b/src/__tests__/actions/chat.test.ts
@@ -41,17 +41,18 @@ describe("chat actions", () => {
 	});
 
 	describe("upsertChat", () => {
-		it("creates new chat with id, name, and createdAt", () => {
+		it("creates new chat with id, name, createdAt, and folderId", () => {
 			upsertChat("chat-1", "My First Chat");
 
 			expect(mockMainStore.setRow).toHaveBeenCalledWith("chats", "chat-1", {
 				id: "chat-1",
 				name: "My First Chat",
 				createdAt: "2024-01-15T10:30:00.000Z",
+				folderId: "",
 			});
 		});
 
-		it("updates existing chat and preserves createdAt", () => {
+		it("updates existing chat and preserves createdAt and folderId", () => {
 			const originalCreatedAt = "2024-01-01T00:00:00.000Z";
 			seedMockMainStore(
 				{},
@@ -61,6 +62,7 @@ describe("chat actions", () => {
 							id: "chat-1",
 							name: "Original Name",
 							createdAt: originalCreatedAt,
+							folderId: "",
 						},
 					},
 				},
@@ -72,6 +74,7 @@ describe("chat actions", () => {
 				id: "chat-1",
 				name: "Updated Name",
 				createdAt: originalCreatedAt, // Should preserve original createdAt
+				folderId: "",
 			});
 		});
 	});
@@ -168,6 +171,7 @@ describe("chat actions", () => {
 							id: "chat-1",
 							name: "Original Name",
 							createdAt: "2024-01-01T00:00:00.000Z",
+							folderId: "",
 						},
 					},
 				},
@@ -179,6 +183,7 @@ describe("chat actions", () => {
 				id: "chat-1",
 				name: "New Name",
 				createdAt: "2024-01-01T00:00:00.000Z",
+				folderId: "",
 			});
 		});
 

--- a/src/__tests__/stores/main-store-schema.test.ts
+++ b/src/__tests__/stores/main-store-schema.test.ts
@@ -38,13 +38,14 @@ describe("store schema sync validation", () => {
 	});
 
 	describe("cell schema completeness", () => {
-		it("chats table should have id, name, createdAt cells", () => {
+		it("chats table should have id, name, createdAt, folderId cells", () => {
 			const chatCells = Object.keys(tablesSchemaMainStore.chats);
 
 			expect(chatCells).toContain("id");
 			expect(chatCells).toContain("name");
 			expect(chatCells).toContain("createdAt");
-			expect(chatCells).toHaveLength(3);
+			expect(chatCells).toContain("folderId");
+			expect(chatCells).toHaveLength(4);
 		});
 
 		it("messages table should have id, chatId, contents, role, createdAt cells", () => {


### PR DESCRIPTION
## Summary
- Add expo-image-manipulator mock to chat-background tests
- Add constants module mock to ai-chat-model tests to fix circular dependency
- Update schema test to expect folderId field in chats table
- Update chat action tests to include folderId in assertions

## Test plan
- [x] All 99 tests pass locally with `npm run test`

Closes #58 