### PR TITLE
feat: use app icon as AI avatar in chat

### DIFF
--- a/app/chat.tsx
+++ b/app/chat.tsx
@@ -89,6 +89,7 @@ export default function ChatPage() {
 	const {
 		defaultContainerStyle,
 		renderBubble,
+		renderAvatar,
 		renderInputToolbar,
 		InputToolbar,
 	} = useChatRenderers({
@@ -198,7 +199,8 @@ export default function ChatPage() {
 							user={{
 								_id: 1,
 							}}
-							renderAvatar={null}
+							renderAvatar={renderAvatar}
+							renderAvatarOnTop
 							alwaysShowSend
 							isTyping={false}
 							bottomOffset={0}

--- a/hooks/useChatRenderers.tsx
+++ b/hooks/useChatRenderers.tsx
@@ -6,12 +6,16 @@ import { TypingIndicator } from "@/components/ui/typing-indicator";
 import { View } from "@/components/ui/view";
 import { useColorScheme } from "@/hooks/useColorScheme";
 import { useKeyboardHeight } from "@/hooks/useKeyboardHeight";
+import { getAppIconPresetById } from "@/src/data/app-icon-presets";
+import type { AppIconVariant } from "@/src/data/app-icon-presets";
 import type { ChatRenderersProps } from "@/src/types/chat";
 import { Colors } from "@/theme/colors";
+import { Image } from "expo-image";
 import { SendHorizonal } from "lucide-react-native";
 import { useCallback, useEffect } from "react";
 import { Dimensions } from "react-native";
 import { Bubble } from "react-native-gifted-chat";
+import { useValue } from "tinybase/ui-react";
 import Animated, {
 	useAnimatedStyle,
 	useSharedValue,
@@ -34,6 +38,10 @@ export function useChatRenderers({
 }: ChatRenderersProps & { isFullPage?: boolean }) {
 	const colorScheme = useColorScheme() ?? "light";
 	const theme = Colors[colorScheme];
+	const appIconVariant = useValue("app_icon_variant") as
+		| AppIconVariant
+		| undefined;
+	const appIconPreset = getAppIconPresetById(appIconVariant || "Default");
 	const { keyboardHeight, keyboardAnimationDuration } = useKeyboardHeight();
 
 	const BASE_BOTTOM = isFullPage ? PAGE_BASE_BOTTOM : SHEET_BASE_BOTTOM;
@@ -213,12 +221,30 @@ export function useChatRenderers({
 		[isTyping, setIsInputFocused, isNewChat, animatedToolbarStyle],
 	);
 
+	const renderAvatar = useCallback(
+		(props: { position: "left" | "right" }) => {
+			if (props.position === "right") return null;
+			return (
+				<Image
+					source={appIconPreset?.image}
+					style={{
+						width: 28,
+						height: 28,
+						borderRadius: 14,
+					}}
+				/>
+			);
+		},
+		[appIconPreset],
+	);
+
 	const defaultContainerStyle = {
 		paddingHorizontal: 8,
 	};
 
 	return {
 		renderBubble,
+		renderAvatar,
 		renderInputToolbar,
 		renderFooter,
 		defaultContainerStyle,


### PR DESCRIPTION
## Summary
- Show the user's chosen app icon as a circular avatar next to AI messages in chat
- Avatar updates reactively when the app icon is changed in settings
- User messages remain without an avatar

Closes #137

## Test plan
- [x] Open a chat with existing messages and confirm the AI avatar shows the current app icon
- [x] Change the app icon in settings and return to chat -- avatar should reflect the new icon
- [x] User messages should have no avatar
- [x] Streaming/typing messages should also show the avatar
- [x] Last message avatar should be properly positioned (not pushed off-screen)

## Screenshot
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2026-02-15 at 21 19 23" src="https://github.com/user-attachments/assets/33e7e579-3c6a-4fca-84fa-9108a8e721de" />

