### PR TITLE
Feature - sliding context window

### DIFF
--- a/app/chat.tsx
+++ b/app/chat.tsx
@@ -5,6 +5,7 @@ import { SuggestionCards } from "@/components/suggestion-cards";
 import { PromptDialog } from "@/components/ui/prompt-dialog";
 import { Text } from "@/components/ui/text";
 import { View } from "@/components/ui/view";
+import { useAIChat } from "@/contexts/AIChatContext";
 import { useChatCompletion } from "@/hooks/useChatCompletion";
 import { useChatMessages } from "@/hooks/useChatMessages";
 import { useChatRenderers } from "@/hooks/useChatRenderers";
@@ -73,13 +74,14 @@ export default function ChatPage() {
 	// Messages from TinyBase
 	const messages = useChatMessages(currentChatId);
 
-	const totalChars = messages.reduce((sum, m) => sum + m.text.length, 0);
+	// Get contextSize from AI context for truncation warning
+	const { contextSize } = useAIChat();
 
 	// Show warning when conversation will be truncated
 	const showTruncationWarning = useMemo(() => {
 		const totalChars = messages.reduce((sum, m) => sum + m.text.length, 0);
-		return wouldTruncate(totalChars);
-	}, [messages]);
+		return wouldTruncate(totalChars, contextSize);
+	}, [messages, contextSize]);
 
 	// AI completion orchestration
 	const { isAiTyping, streamingText, sendMessage, clearInferenceCache } =

--- a/contexts/AIChatContext.tsx
+++ b/contexts/AIChatContext.tsx
@@ -12,6 +12,8 @@ import {
 } from "react";
 import type { RuntimeConfig } from "whisper-llm-cards";
 
+const DEFAULT_CONTEXT_SIZE = 2048;
+
 export type AIChatConfig = {
 	ggufPath: string;
 	runtime?: RuntimeConfig;
@@ -24,6 +26,7 @@ export type AIChatMessage = {
 
 type AIChatContextType = {
 	isLoaded: boolean;
+	contextSize: number;
 	loadModel: (config: AIChatConfig) => Promise<void>;
 	completion: (
 		messages: AIChatMessage[],
@@ -37,6 +40,7 @@ const AIChatContext = createContext<AIChatContextType | undefined>(undefined);
 export function AIChatProvider({ children }: { children: ReactNode }) {
 	const [context, setContext] = useState<LlamaContext | undefined>();
 	const [isLoaded, setIsLoaded] = useState(false);
+	const [contextSize, setContextSize] = useState(DEFAULT_CONTEXT_SIZE);
 	const stopWordsRef = useRef<string[]>([]);
 	const runtimeConfigRef = useRef<RuntimeConfig | undefined>(undefined);
 
@@ -112,6 +116,7 @@ export function AIChatProvider({ children }: { children: ReactNode }) {
 
 				setContext(llamaContext);
 				setIsLoaded(true);
+				setContextSize(runtime?.n_ctx ?? DEFAULT_CONTEXT_SIZE);
 				runtimeConfigRef.current = runtime;
 				stopWordsRef.current = runtime?.stop ?? [];
 
@@ -178,7 +183,7 @@ export function AIChatProvider({ children }: { children: ReactNode }) {
 
 	return (
 		<AIChatContext.Provider
-			value={{ isLoaded, loadModel, completion, clearCache }}
+			value={{ isLoaded, contextSize, loadModel, completion, clearCache }}
 		>
 			{children}
 		</AIChatContext.Provider>

--- a/hooks/useChatCompletion.ts
+++ b/hooks/useChatCompletion.ts
@@ -104,7 +104,7 @@ export function useChatCompletion(
 					const truncatedMessages = truncateMessages(
 						systemMessage,
 						conversationMessages,
-						2048,
+						aiChat.contextSize,
 					);
 
 					const response = await aiChat.completion(

--- a/src/utils/context-window.ts
+++ b/src/utils/context-window.ts
@@ -1,6 +1,6 @@
 // Simple character heuristic: ~4 chars per token
 const CHARS_PER_TOKEN = 4;
-const CONTEXT_SIZE = 2048;
+export const DEFAULT_CONTEXT_SIZE = 2048;
 const RESPONSE_RESERVE = 300;
 // Approximate system message size for warning calculation
 const SYSTEM_MESSAGE_ESTIMATE = 200;
@@ -9,17 +9,20 @@ export function estimateTokens(text: string): number {
 	return Math.ceil(text.length / CHARS_PER_TOKEN);
 }
 
-export function wouldTruncate(totalMessageChars: number): boolean {
+export function wouldTruncate(
+	totalMessageChars: number,
+	contextSize: number = DEFAULT_CONTEXT_SIZE,
+): boolean {
 	const messageTokens = Math.ceil(totalMessageChars / CHARS_PER_TOKEN);
-	const available = CONTEXT_SIZE - SYSTEM_MESSAGE_ESTIMATE - RESPONSE_RESERVE;
+	const available = contextSize - SYSTEM_MESSAGE_ESTIMATE - RESPONSE_RESERVE;
 	return messageTokens > available;
 }
 
 export function truncateMessages(
 	systemMessage: string,
-	messages: { role: string; content: string }[],
-	maxTokens = CONTEXT_SIZE,
-): { role: string; content: string }[] {
+	messages: { role: "user" | "assistant" | "system"; content: string }[],
+	maxTokens = DEFAULT_CONTEXT_SIZE,
+): { role: "user" | "assistant" | "system"; content: string }[] {
 	const available =
 		maxTokens - estimateTokens(systemMessage) - RESPONSE_RESERVE;
 


### PR DESCRIPTION
### #134 Basic sliding context window with UI warning for long conversations

> [!WARNING] 
> Blocked by #156 (need this PR merged first) - once merged, this PR needs to be updated to use inference config `n_ctx` as limit

---

Brings in a simple sliding-context window for conversations, so the LLM can continue talking.

- Basic token estimation (rapid)
- Sliding window truncation, keeping system prompt and latest messages

- When truncating, show small UI warning for user, recommending they start a new conversation

<img width="349" height="298" alt="image" src="https://github.com/user-attachments/assets/11e36552-57c3-467e-a06d-54619385f185" />
