### PR TITLE
refactor(openai): replace manual HTTP/SSE with AI SDK

### DIFF
--- a/src/__tests__/ai-providers/openai-provider.test.ts
+++ b/src/__tests__/ai-providers/openai-provider.test.ts
@@ -1,0 +1,503 @@
+import { createStore } from "tinybase";
+import type { Store } from "tinybase";
+import * as SecureStore from "expo-secure-store";
+
+// Mock secure store
+jest.mock("expo-secure-store");
+
+const { __resetStore } = SecureStore as typeof SecureStore & {
+	__resetStore: () => void;
+};
+
+// Mock @ai-sdk/openai
+const mockResponses = jest.fn();
+const mockCreateOpenAI = jest.fn(() => {
+	const provider = jest.fn();
+	provider.responses = mockResponses;
+	return provider;
+});
+jest.mock("@ai-sdk/openai", () => ({
+	createOpenAI: (...args: unknown[]) => mockCreateOpenAI(...args),
+}));
+
+// Mock ai package streamText
+const mockTextStream = {
+	[Symbol.asyncIterator]: jest.fn(),
+};
+const mockStreamTextResult = {
+	textStream: mockTextStream,
+	// biome-ignore lint/suspicious/noThenProperty: mock must be thenable to simulate streamText's promise-like return
+	then: (resolve: (v: unknown) => void) =>
+		resolve({ finishReason: "stop", usage: { promptTokens: 10, completionTokens: 5 } }),
+};
+const mockStreamText = jest.fn(() => mockStreamTextResult);
+jest.mock("ai", () => ({
+	streamText: (...args: unknown[]) => mockStreamText(...args),
+}));
+
+// Mock expo/fetch
+const mockExpoFetch = jest.fn();
+jest.mock("expo/fetch", () => ({
+	fetch: (...args: unknown[]) => mockExpoFetch(...args),
+}));
+
+// Mock message-converter
+jest.mock("../../ai-providers/message-converter", () => ({
+	convertMessagesForAISDK: jest.fn(async (messages: unknown[]) => messages),
+}));
+
+// Mock token-refresh
+const mockGetValidAccessToken = jest.fn();
+jest.mock("../../ai-providers/token-refresh", () => ({
+	getValidAccessToken: (...args: unknown[]) => mockGetValidAccessToken(...args),
+}));
+
+// Mock secure-credentials
+const mockGetCredential = jest.fn();
+const mockDeleteProviderCredentials = jest.fn();
+jest.mock("../../actions/secure-credentials", () => ({
+	getCredential: (...args: unknown[]) => mockGetCredential(...args),
+	setCredential: jest.fn(),
+	deleteProviderCredentials: (...args: unknown[]) => mockDeleteProviderCredentials(...args),
+}));
+
+// Mock oauth
+const mockRequestDeviceCode = jest.fn();
+const mockPollForAuthorization = jest.fn();
+const mockCancelPolling = jest.fn();
+jest.mock("../../ai-providers/openai/oauth", () => ({
+	requestDeviceCode: (...args: unknown[]) => mockRequestDeviceCode(...args),
+	pollForAuthorization: (...args: unknown[]) => mockPollForAuthorization(...args),
+	cancelPolling: (...args: unknown[]) => mockCancelPolling(...args),
+	OPENAI_CLIENT_ID: "test-client-id",
+	OPENAI_TOKEN_URL: "https://auth.openai.com/oauth/token",
+}));
+
+// Import after mocks
+import { createOpenAIProvider } from "../../ai-providers/openai/provider";
+
+describe("OpenAI Provider", () => {
+	let store: Store;
+	let provider: ReturnType<typeof createOpenAIProvider>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		__resetStore();
+		store = createStore();
+		provider = createOpenAIProvider(store);
+
+		// Default: token refresh returns a valid token
+		mockGetValidAccessToken.mockResolvedValue("test-access-token");
+		mockGetCredential.mockResolvedValue("test-account-id");
+
+		// Default: stream yields nothing (override in specific tests)
+		mockTextStream[Symbol.asyncIterator].mockReturnValue({
+			next: jest.fn(() => Promise.resolve({ value: undefined, done: true })),
+		});
+	});
+
+	describe("identity", () => {
+		it("has correct provider metadata", () => {
+			expect(provider.id).toBe("openai");
+			expect(provider.name).toBe("ChatGPT");
+			expect(provider.type).toBe("cloud");
+			expect(provider.defaultModelId).toBe("gpt-5.4");
+			expect(provider.capabilities).toEqual({
+				oauth: true,
+				download: false,
+				userApiKey: false,
+			});
+		});
+	});
+
+	describe("enable()", () => {
+		it("creates TinyBase row with needs_setup status", () => {
+			provider.enable();
+			const row = store.getRow("aiProviders", "openai");
+			expect(row.id).toBe("openai");
+			expect(row.status).toBe("needs_setup");
+			expect(row.error).toBe("");
+			expect(row.selectedModelId).toBe("");
+		});
+	});
+
+	describe("disable()", () => {
+		it("cancels polling, deletes credentials, and removes row", async () => {
+			provider.enable();
+			await provider.disable();
+
+			expect(mockCancelPolling).toHaveBeenCalled();
+			expect(mockDeleteProviderCredentials).toHaveBeenCalledWith("openai");
+			expect(store.getRow("aiProviders", "openai")).toEqual({});
+		});
+	});
+
+	describe("setup()", () => {
+		it("transitions to ready when token exists", async () => {
+			provider.enable();
+			await provider.setup();
+
+			expect(store.getCell("aiProviders", "openai", "status")).toBe("ready");
+			expect(store.getCell("aiProviders", "openai", "error")).toBe("");
+		});
+
+		it("transitions to needs_setup when no token", async () => {
+			provider.enable();
+			mockGetValidAccessToken.mockResolvedValue(null);
+
+			await provider.setup();
+
+			expect(store.getCell("aiProviders", "openai", "status")).toBe("needs_setup");
+		});
+	});
+
+	describe("startOAuth()", () => {
+		it("requests device code and starts polling", async () => {
+			provider.enable();
+			mockRequestDeviceCode.mockResolvedValue({
+				userCode: "ABCD-1234",
+				deviceAuthId: "auth-123",
+			});
+			mockPollForAuthorization.mockResolvedValue(undefined);
+
+			await provider.startOAuth();
+
+			expect(mockRequestDeviceCode).toHaveBeenCalledWith(store);
+			expect(mockPollForAuthorization).toHaveBeenCalledWith(
+				store,
+				"auth-123",
+				"ABCD-1234",
+			);
+
+			// Device code stored in modelCard for UI display
+			const modelCard = JSON.parse(
+				store.getCell("aiProviders", "openai", "modelCard") as string,
+			);
+			expect(modelCard.deviceCode).toBe("ABCD-1234");
+		});
+
+		it("does nothing when device code request fails", async () => {
+			provider.enable();
+			mockRequestDeviceCode.mockResolvedValue(null);
+
+			await provider.startOAuth();
+
+			expect(mockPollForAuthorization).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("models()", () => {
+		it("returns all Codex models", async () => {
+			const models = await provider.models();
+			expect(models.length).toBe(8);
+			expect(models[0].id).toBe("gpt-5.4");
+		});
+
+		it("filters by search query", async () => {
+			const models = await provider.models("codex");
+			expect(models.every((m) => m.id.includes("codex") || m.name.toLowerCase().includes("codex"))).toBe(true);
+		});
+
+		it("puts default model first when no search", async () => {
+			const models = await provider.models();
+			expect(models[0].id).toBe("gpt-5.4");
+		});
+	});
+
+	describe("setModel()", () => {
+		it("updates selectedModelId in TinyBase", () => {
+			provider.enable();
+			provider.setModel("gpt-5.2");
+			expect(store.getCell("aiProviders", "openai", "selectedModelId")).toBe("gpt-5.2");
+		});
+	});
+
+	describe("completion()", () => {
+		beforeEach(() => {
+			provider.enable();
+			store.setCell("aiProviders", "openai", "selectedModelId", "gpt-5.4");
+		});
+
+		it("streams tokens via onToken callback", async () => {
+			const tokens: string[] = [];
+			const chunks = ["Hello", " world", "!"];
+			let index = 0;
+			mockTextStream[Symbol.asyncIterator].mockReturnValue({
+				next: jest.fn(() => {
+					if (index < chunks.length) {
+						return Promise.resolve({ value: chunks[index++], done: false });
+					}
+					return Promise.resolve({ value: undefined, done: true });
+				}),
+			});
+
+			const result = await provider.completion(
+				[{ role: "user", content: "Hi" }],
+				(token) => tokens.push(token),
+			);
+
+			expect(tokens).toEqual(["Hello", " world", "!"]);
+			expect(result.content).toBe("Hello world!");
+			expect(result.finishReason).toBe("stop");
+		});
+
+		it("creates OpenAI provider with Codex baseURL and custom fetch", async () => {
+			await provider.completion(
+				[{ role: "user", content: "Hi" }],
+				jest.fn(),
+			);
+
+			expect(mockCreateOpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					baseURL: "https://chatgpt.com/backend-api/codex",
+					apiKey: "",
+				}),
+			);
+		});
+
+		it("uses responses() model, not chat()", async () => {
+			const mockModel = {};
+			mockResponses.mockReturnValue(mockModel);
+
+			await provider.completion(
+				[{ role: "user", content: "Hi" }],
+				jest.fn(),
+			);
+
+			expect(mockResponses).toHaveBeenCalledWith("gpt-5.4");
+			expect(mockStreamText).toHaveBeenCalledWith(
+				expect.objectContaining({
+					model: mockModel,
+				}),
+			);
+		});
+
+		it("returns error when no token", async () => {
+			mockGetValidAccessToken.mockResolvedValue(null);
+
+			const result = await provider.completion(
+				[{ role: "user", content: "Hi" }],
+				jest.fn(),
+			);
+
+			expect(result.finishReason).toBe("error");
+			expect(result.content).toBe("");
+			expect(mockStreamText).not.toHaveBeenCalled();
+		});
+
+		it("returns error when no model selected", async () => {
+			store.setCell("aiProviders", "openai", "selectedModelId", "");
+
+			const result = await provider.completion(
+				[{ role: "user", content: "Hi" }],
+				jest.fn(),
+			);
+
+			expect(result.finishReason).toBe("error");
+		});
+
+		it("returns cancelled on abort", async () => {
+			let callCount = 0;
+			mockTextStream[Symbol.asyncIterator].mockReturnValue({
+				next: jest.fn(() => {
+					callCount++;
+					if (callCount === 1) {
+						return Promise.resolve({ value: "partial", done: false });
+					}
+					const abortError = new Error("aborted");
+					abortError.name = "AbortError";
+					return Promise.reject(abortError);
+				}),
+			});
+
+			const result = await provider.completion(
+				[{ role: "user", content: "Hi" }],
+				(token) => {
+					if (token === "partial") provider.stopCompletion();
+				},
+			);
+
+			expect(result.finishReason).toBe("cancelled");
+			expect(result.content).toBe("partial");
+		});
+
+		it("maps length finishReason", async () => {
+			mockStreamText.mockReturnValueOnce({
+				textStream: mockTextStream,
+				// biome-ignore lint/suspicious/noThenProperty: mock must be thenable to simulate streamText's promise-like return
+				then: (resolve: (v: unknown) => void) =>
+					resolve({ finishReason: "length", usage: {} }),
+			});
+
+			const result = await provider.completion(
+				[{ role: "user", content: "Hi" }],
+				jest.fn(),
+			);
+
+			expect(result.finishReason).toBe("length");
+		});
+
+		it("returns usage stats", async () => {
+			const result = await provider.completion(
+				[{ role: "user", content: "Hi" }],
+				jest.fn(),
+			);
+
+			expect(result.usage).toEqual({
+				promptTokens: 10,
+				completionTokens: 5,
+			});
+		});
+	});
+
+	describe("codexFetch body patching", () => {
+		beforeEach(() => {
+			provider.enable();
+			store.setCell("aiProviders", "openai", "selectedModelId", "gpt-5.4");
+		});
+
+		it("injects store: false and extracts instructions from developer message", async () => {
+			// Capture the custom fetch function passed to createOpenAI
+			let capturedFetch: Function | undefined;
+			mockCreateOpenAI.mockImplementation((opts: Record<string, unknown>) => {
+				capturedFetch = opts.fetch as Function;
+				const p = jest.fn();
+				p.responses = mockResponses;
+				return p;
+			});
+
+			// Trigger completion to create the provider (which captures codexFetch)
+			await provider.completion(
+				[{ role: "user", content: "test" }],
+				jest.fn(),
+			).catch(() => {});
+
+			expect(capturedFetch).toBeDefined();
+
+			// Simulate a request body like the AI SDK would send
+			const requestBody = JSON.stringify({
+				model: "gpt-5.4",
+				input: [
+					{ role: "developer", content: "System instructions here" },
+					{ role: "user", content: "Hello" },
+				],
+				stream: true,
+			});
+
+			mockExpoFetch.mockResolvedValue(new Response("ok"));
+
+			await capturedFetch!("https://example.com/responses", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: requestBody,
+			});
+
+			const callArgs = mockExpoFetch.mock.calls[0];
+			const sentBody = JSON.parse(callArgs[1].body as string);
+
+			// store: false should be injected
+			expect(sentBody.store).toBe(false);
+
+			// developer message should be extracted to instructions
+			expect(sentBody.instructions).toBe("System instructions here");
+
+			// developer message should be removed from input
+			expect(sentBody.input).toEqual([
+				{ role: "user", content: "Hello" },
+			]);
+		});
+
+		it("injects Codex-specific headers", async () => {
+			let capturedFetch: Function | undefined;
+			mockCreateOpenAI.mockImplementation((opts: Record<string, unknown>) => {
+				capturedFetch = opts.fetch as Function;
+				const p = jest.fn();
+				p.responses = mockResponses;
+				return p;
+			});
+
+			await provider.completion(
+				[{ role: "user", content: "test" }],
+				jest.fn(),
+			).catch(() => {});
+
+			mockExpoFetch.mockResolvedValue(new Response("ok"));
+
+			await capturedFetch!("https://example.com/responses", {
+				method: "POST",
+				headers: {},
+				body: "{}",
+			});
+
+			const callArgs = mockExpoFetch.mock.calls[0];
+			const sentHeaders = callArgs[1].headers as Record<string, string>;
+
+			expect(sentHeaders.authorization).toBe("Bearer test-access-token");
+			expect(sentHeaders["chatgpt-account-id"]).toBe("test-account-id");
+			expect(sentHeaders.originator).toBe("codex_cli_rs");
+		});
+	});
+
+	describe("stopCompletion()", () => {
+		it("does not throw when no active completion", () => {
+			expect(() => provider.stopCompletion()).not.toThrow();
+		});
+	});
+
+	describe("isConfigured()", () => {
+		it("returns false when no token or model", () => {
+			expect(provider.isConfigured()).toBe(false);
+		});
+
+		it("returns true after setup and model selection", async () => {
+			provider.enable();
+			await provider.setup();
+			provider.setModel("gpt-5.4");
+			expect(provider.isConfigured()).toBe(true);
+		});
+	});
+
+	describe("getSystemMessage()", () => {
+		it("returns system prompt with date", () => {
+			const msg = provider.getSystemMessage([]);
+			expect(msg).toContain("helpful");
+			expect(msg).toContain("assistant");
+		});
+	});
+
+	describe("getContextSize()", () => {
+		it("returns model-specific context size", () => {
+			provider.enable();
+			provider.setModel("gpt-5.3-codex");
+			expect(provider.getContextSize()).toBe(192000);
+		});
+
+		it("returns default when no model selected", () => {
+			expect(provider.getContextSize()).toBe(128000);
+		});
+	});
+
+	describe("getMultimodalCapabilities()", () => {
+		it("returns vision for GPT-5 models", () => {
+			provider.enable();
+			provider.setModel("gpt-5.4");
+			const caps = provider.getMultimodalCapabilities();
+			expect(caps.vision).toBe(true);
+			expect(caps.audio).toBe(true);
+			expect(caps.files).toBe(false);
+		});
+
+		it("returns no vision when no model selected", () => {
+			const caps = provider.getMultimodalCapabilities();
+			expect(caps.vision).toBe(false);
+			expect(caps.audio).toBe(true);
+		});
+	});
+
+	describe("teardown()", () => {
+		it("cancels polling and aborts", async () => {
+			await provider.teardown();
+			expect(mockCancelPolling).toHaveBeenCalled();
+		});
+	});
+});

--- a/src/ai-providers/openai/provider.ts
+++ b/src/ai-providers/openai/provider.ts
@@ -2,9 +2,12 @@ import {
 	deleteProviderCredentials,
 	getCredential,
 } from "@/src/actions/secure-credentials";
-import * as FileSystem from "expo-file-system";
+import { createOpenAI } from "@ai-sdk/openai";
+import { streamText } from "ai";
 import { fetch as expoFetch } from "expo/fetch";
 import type { Store } from "tinybase";
+import { convertMessagesForAISDK } from "../message-converter";
+import { getValidAccessToken } from "../token-refresh";
 import type {
 	AIProvider,
 	CompletionMessage,
@@ -14,13 +17,12 @@ import type {
 } from "../types";
 import { DEFAULT_CONSTRAINTS, NO_MULTIMODAL } from "../types";
 import {
-	requestDeviceCode,
-	pollForAuthorization,
 	cancelPolling,
 	OPENAI_CLIENT_ID,
 	OPENAI_TOKEN_URL,
+	pollForAuthorization,
+	requestDeviceCode,
 } from "./oauth";
-import { getValidAccessToken } from "../token-refresh";
 
 const CODEX_API_BASE = "https://chatgpt.com/backend-api/codex";
 const DEFAULT_CLOUD_CONTEXT_SIZE = 128000;
@@ -37,7 +39,11 @@ const CODEX_MODELS: ProviderModel[] = [
 	{ id: "gpt-5.2", name: "GPT-5.2", contextLength: 128000 },
 	{ id: "gpt-5.1-codex", name: "GPT-5.1 Codex", contextLength: 192000 },
 	{ id: "gpt-5.1-codex-max", name: "GPT-5.1 Codex Max", contextLength: 192000 },
-	{ id: "gpt-5.1-codex-mini", name: "GPT-5.1 Codex Mini", contextLength: 192000 },
+	{
+		id: "gpt-5.1-codex-mini",
+		name: "GPT-5.1 Codex Mini",
+		contextLength: 192000,
+	},
 ];
 
 // Module-scoped runtime state
@@ -68,12 +74,71 @@ export function createOpenAIProvider(store: Store): AIProvider {
 
 	function getSelectedModelId(): string {
 		return (
-			(store.getCell(
-				"aiProviders",
-				"openai",
-				"selectedModelId",
-			) as string) || ""
+			(store.getCell("aiProviders", "openai", "selectedModelId") as string) ||
+			""
 		);
+	}
+
+	/**
+	 * Custom fetch wrapper for the Codex API.
+	 * Handles token refresh, injects required headers, and patches the
+	 * request body to include `store: false` as required by the Codex backend.
+	 *
+	 */
+	async function codexFetch(
+		url: RequestInfo | URL,
+		init?: RequestInit,
+	): Promise<Response> {
+		// Refresh token before each request
+		await refreshAccessToken();
+		const token = getAccessToken();
+		const accountId = await getAccountId();
+
+		const headers = new Headers(init?.headers);
+		headers.set("Authorization", `Bearer ${token}`);
+		headers.set("ChatGPT-Account-Id", accountId);
+		headers.set("originator", "codex_cli_rs");
+
+		// Patch the request body for Codex backend requirements:
+		// 1. Add store: false
+		// 2. Extract developer/system message from input[] into top-level instructions
+		//    (Codex requires instructions as a separate field, not inline in input)
+		let body = init?.body;
+		if (typeof body === "string") {
+			try {
+				const parsed = JSON.parse(body) as Record<string, unknown>;
+				parsed.store = false;
+
+				// Move developer message from input to instructions
+				const input = parsed.input as
+					| Array<Record<string, unknown>>
+					| undefined;
+				if (input && !parsed.instructions) {
+					const devIdx = input.findIndex((m) => m.role === "developer");
+					if (devIdx !== -1) {
+						parsed.instructions =
+							input[devIdx].content ?? "You are a helpful assistant.";
+						input.splice(devIdx, 1);
+					}
+				}
+
+				body = JSON.stringify(parsed);
+			} catch {
+				// Not JSON — leave body as-is
+			}
+		}
+
+		// Convert Headers to plain object for expoFetch compatibility
+		const headersObj: Record<string, string> = {};
+		headers.forEach((value, key) => {
+			headersObj[key] = value;
+		});
+
+		return expoFetch(url, {
+			...init,
+			headers: headersObj,
+			body,
+		} as RequestInit);
 	}
 
 	const provider: AIProvider = {
@@ -194,7 +259,6 @@ export function createOpenAIProvider(store: Store): AIProvider {
 			await refreshAccessToken();
 			const token = getAccessToken();
 			const modelId = getSelectedModelId();
-			const accountId = await getAccountId();
 
 			if (!token || !modelId) {
 				return { content: "", finishReason: "error" };
@@ -206,121 +270,37 @@ export function createOpenAIProvider(store: Store): AIProvider {
 			let content = "";
 
 			try {
-				// Build input array in the Responses API format
-				const input: Array<Record<string, unknown>> = [];
-				for (const msg of messages) {
-					if (typeof msg.content === "string") {
-						input.push({
-							role: msg.role === "system" ? "developer" : msg.role,
-							content: msg.content,
-						});
-					} else {
-						// Multimodal parts — convert to Responses API format
-						const parts: Array<Record<string, unknown>> = [];
-						for (const part of msg.content) {
-							if (part.type === "text") {
-								parts.push({ type: "input_text", text: part.text });
-							} else if (part.type === "image") {
-								try {
-									const file = new FileSystem.File(part.uri);
-									if (!file.exists) throw new Error(`File not found: ${part.uri}`);
-									const base64 = await file.base64();
-									const mimeType = ["image/jpeg", "image/png", "image/gif", "image/webp"].includes(part.mimeType)
-										? part.mimeType
-										: "image/jpeg";
-									parts.push({
-										type: "input_image",
-										image_url: `data:${mimeType};base64,${base64}`,
-									});
-								} catch {
-									parts.push({ type: "input_text", text: `[${part.alt}]` });
-								}
-							} else if (part.type === "audio") {
-								// Use alt text (transcription) for audio
-								parts.push({ type: "input_text", text: `[${part.alt}]` });
-							} else if (part.type === "file") {
-								parts.push({ type: "input_text", text: `[${part.alt}]` });
-							}
-						}
-						input.push({
-							role: msg.role === "system" ? "developer" : msg.role,
-							content: parts,
-						});
-					}
+				// Convert multimodal content parts to AI SDK format
+				const convertedMessages = await convertMessagesForAISDK(messages);
+
+				// Create OpenAI provider pointing at Codex API with custom fetch
+				const openai = createOpenAI({
+					baseURL: CODEX_API_BASE,
+					apiKey: "",
+					fetch: codexFetch as unknown as typeof globalThis.fetch,
+				});
+
+				const result = streamText({
+					model: openai.responses(modelId),
+					messages: convertedMessages,
+					abortSignal: localAbortController.signal,
+				});
+
+				for await (const chunk of result.textStream) {
+					content += chunk;
+					onToken(chunk);
 				}
 
-				const response = await expoFetch(
-					`${CODEX_API_BASE}/responses`,
-					{
-						method: "POST",
-						headers: {
-							"Content-Type": "application/json",
-							Authorization: `Bearer ${token}`,
-							"ChatGPT-Account-Id": accountId,
-							originator: "codex_cli_rs",
-						},
-						body: JSON.stringify({
-							model: modelId,
-							instructions: input.find((m) => m.role === "developer")?.content ?? "You are a helpful assistant.",
-							input: input.filter((m) => m.role !== "developer"),
-							stream: true,
-							store: false,
-						}),
-						signal: localAbortController.signal,
-					},
-				);
-
-				if (!response.ok) {
-					const errorText = await response.text();
-					throw new Error(
-						`Codex API error ${response.status}: ${errorText}`,
-					);
-				}
-
-				// Parse SSE stream
-				const reader = response.body?.getReader();
-				if (!reader) {
-					throw new Error("No response body");
-				}
-
-				const decoder = new TextDecoder();
-				let buffer = "";
-
-				while (true) {
-					const { done, value } = await reader.read();
-					if (done) break;
-
-					buffer += decoder.decode(value, { stream: true });
-					const lines = buffer.split("\n");
-					buffer = lines.pop() ?? "";
-
-					for (const line of lines) {
-						if (!line.startsWith("data: ")) continue;
-						const data = line.slice(6).trim();
-						if (data === "[DONE]") continue;
-
-						try {
-							const event = JSON.parse(data) as {
-								type?: string;
-								delta?: string;
-								status?: string;
-							};
-							if (
-								event.type === "response.output_text.delta" &&
-								event.delta
-							) {
-								content += event.delta;
-								onToken(event.delta);
-							}
-						} catch {
-							// Skip unparseable events
-						}
-					}
-				}
+				const finalResult = await result;
 
 				return {
 					content,
-					finishReason: "stop",
+					finishReason:
+						finalResult.finishReason === "length" ? "length" : "stop",
+					usage: {
+						promptTokens: finalResult.usage?.promptTokens,
+						completionTokens: finalResult.usage?.completionTokens,
+					},
 				};
 			} catch (error) {
 				if (localAbortController.signal.aborted) {


### PR DESCRIPTION
## Summary
- Replaces the custom HTTP request and manual SSE stream parser in the Codex provider with `@ai-sdk/openai` `createOpenAI` + `streamText()`
- Uses a custom fetch wrapper (`codexFetch`) for token refresh, Codex-specific headers (`ChatGPT-Account-Id`, `originator`), and body patching (`store: false`, developer message extraction to `instructions`)
- Uses `openai.responses(modelId)` for the Responses API
- Aligns the OpenAI provider with the same AI SDK pattern used by OpenRouter, Custom Provider, and Apple Intelligence
- Adds 30 unit tests covering provider lifecycle, completion streaming, codexFetch body patching, header injection, and edge cases

## Motivation
This is prep work for tool calling support. With all providers now on the Vercel AI SDK, adding tools becomes trivial -- just pass `tools` to `streamText()`. The manual SSE parser could not support tool calling without significant reverse-engineering of the Codex API response format.

See `docs/tool-calling-plan.md` (Phase 0) for the full tool calling implementation plan.

## Test plan
- [x] 30 unit tests pass (provider lifecycle, streaming, body patching, headers, edge cases)
- [x] Full test suite passes (365 tests)
- [x] Manually tested on device -- completions stream correctly via Codex API
- [x] OAuth flow verified end-to-end
- [x] Multimodal (image) messages verified with GPT-5 models