### PR TITLE
fix: Improved Hugging Face onboarding flow and fixed downloaded state out-of-sync issue

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -46,6 +46,7 @@ export default function RootLayout() {
 											<Stack.Screen name="game" />
 											<Stack.Screen name="setup-ai" />
 											<Stack.Screen name="provider-setup/[providerId]" />
+											<Stack.Screen name="provider-setup/huggingface-download" />
 											<Stack.Screen name="callback/[provider]" />
 										</Stack>
 									</ErrorBoundary>

--- a/app/provider-setup/[providerId].tsx
+++ b/app/provider-setup/[providerId].tsx
@@ -7,15 +7,18 @@ import { WhisperAISetup } from "@/components/provider-setup/WhisperAISetup";
 import { Text } from "@/components/ui/text";
 import { View } from "@/components/ui/view";
 import { useLocalSearchParams } from "expo-router";
+import { useValue } from "tinybase/ui-react";
 
 export default function ProviderSetup() {
 	const { providerId, search } = useLocalSearchParams<{ providerId: string; search?: string }>();
+	const onboardedAt = useValue("onboardedAt");
 
 	if (providerId === "whisper-ai") return <WhisperAISetup />;
 	if (providerId === "openrouter") return <OpenRouterSetup />;
 	if (providerId === "openai") return <OpenAISetup />;
 	if (providerId === "custom-provider") return <CustomProviderSetup />;
-	if (providerId === "huggingface") return <HuggingFaceSetup initialSearch={search} />;
+	if (providerId === "huggingface")
+		return <HuggingFaceSetup initialSearch={search} onboarding={!onboardedAt} />;
 	if (providerId === "apple-models") return <AppleModelsSetup />;
 
 	return (

--- a/app/provider-setup/huggingface-download.tsx
+++ b/app/provider-setup/huggingface-download.tsx
@@ -1,0 +1,7 @@
+import { HuggingFaceDownloadScreen } from "@/components/provider-setup/HuggingFaceDownloadScreen";
+import { useLocalSearchParams } from "expo-router";
+
+export default function HuggingFaceDownload() {
+	const { modelId } = useLocalSearchParams<{ modelId: string }>();
+	return <HuggingFaceDownloadScreen modelId={modelId} />;
+}

--- a/components/ProviderAndModelSelector.tsx
+++ b/components/ProviderAndModelSelector.tsx
@@ -428,7 +428,7 @@ function CloudProviderSection({
 	const isReady = status === "ready" || (isDownloadProvider && !!status && status !== "disabled");
 	const isActiveProvider = activeProviderId === provider.id;
 	const isSearching = searchQuery.length > 0;
-	const searchDebounceRef = useRef<ReturnType<typeof setTimeout>>();
+	const searchDebounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 	const [searchModels, setSearchModels] = useState<ProviderModel[]>([]);
 	const [isSearchingApi, setIsSearchingApi] = useState(false);
 

--- a/components/provider-setup/HuggingFaceDownloadScreen.tsx
+++ b/components/provider-setup/HuggingFaceDownloadScreen.tsx
@@ -1,0 +1,364 @@
+import { FlappyBird } from "@/components/flappy-bird";
+import { GradientBackground } from "@/components/gradient-background";
+import { Button } from "@/components/ui/button";
+import { ModeToggle } from "@/components/ui/mode-toggle";
+import { Progress } from "@/components/ui/progress";
+import { Text } from "@/components/ui/text";
+import { View } from "@/components/ui/view";
+import { useAIProvider } from "@/contexts/AIProviderContext";
+import { useColor } from "@/hooks/useColor";
+import { mainStore } from "@/src/stores/main/main-store";
+import { useRouter } from "expo-router";
+import { useEffect, useRef, useState } from "react";
+import { Modal } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import type { Store } from "tinybase";
+import { useCell } from "tinybase/ui-react";
+
+interface HuggingFaceDownloadScreenProps {
+	modelId: string;
+}
+
+export function HuggingFaceDownloadScreen({
+	modelId,
+}: HuggingFaceDownloadScreenProps) {
+	const router = useRouter();
+	const backgroundColor = useColor("background");
+	const { setActiveProvider } = useAIProvider();
+	const store = mainStore as unknown as Store;
+
+	const [isDownloading, setIsDownloading] = useState(false);
+	const [error, setError] = useState<string | undefined>();
+	const [showGame, setShowGame] = useState(false);
+	const hasNavigatedRef = useRef(false);
+	const hasStartedRef = useRef(false);
+
+	// Subscribe to model metadata
+	const displayName = useCell("hfModels", modelId, "displayName") as
+		| string
+		| undefined;
+	const fileSizeBytes = useCell("hfModels", modelId, "fileSizeBytes") as
+		| number
+		| undefined;
+	const downloadedAt = useCell("hfModels", modelId, "downloadedAt") as
+		| string
+		| undefined;
+
+	// Subscribe to provider download state
+	const providerStatus = useCell("aiProviders", "huggingface", "status") as
+		| string
+		| undefined;
+	const progressSizeGB = useCell(
+		"aiProviders",
+		"huggingface",
+		"progressSizeGB",
+	) as number | undefined;
+	const totalSizeGB = useCell("aiProviders", "huggingface", "totalSizeGB") as
+		| number
+		| undefined;
+	const isPaused = useCell("aiProviders", "huggingface", "isPaused") as
+		| boolean
+		| undefined;
+	const downloadError = useCell(
+		"aiProviders",
+		"huggingface",
+		"downloadError",
+	) as string | undefined;
+
+	const fileSizeGB =
+		fileSizeBytes != null
+			? (fileSizeBytes / (1024 * 1024 * 1024)).toFixed(1)
+			: null;
+
+	const downloading = providerStatus === "downloading" && !isPaused;
+	const progressValue =
+		totalSizeGB && progressSizeGB ? progressSizeGB / totalSizeGB : 0;
+	const hasPartialDownload = providerStatus === "downloading" || isPaused;
+
+	// Auto-start download on mount
+	useEffect(() => {
+		if (hasStartedRef.current) return;
+		hasStartedRef.current = true;
+
+		const doStart = async () => {
+			setIsDownloading(true);
+			setError(undefined);
+			try {
+				const { createHuggingFaceProvider } = await import(
+					"@/src/ai-providers/huggingface/provider"
+				);
+				const provider = createHuggingFaceProvider(store);
+				await provider.startDownload?.();
+			} catch (err) {
+				setError(err instanceof Error ? err.message : "Download failed");
+				setIsDownloading(false);
+			}
+		};
+		doStart();
+	}, [store]);
+
+	// Sync local isDownloading state with store
+	useEffect(() => {
+		if (isPaused === false && providerStatus === "downloading") {
+			setIsDownloading(true);
+		} else if (isPaused === true) {
+			setIsDownloading(false);
+		}
+	}, [isPaused, providerStatus]);
+
+	// Show download errors
+	useEffect(() => {
+		if (downloadError) {
+			setError(downloadError);
+			setIsDownloading(false);
+		}
+	}, [downloadError]);
+
+	// Auto-navigate when download completes
+	useEffect(() => {
+		if (hasNavigatedRef.current) return;
+		if (downloadedAt) {
+			hasNavigatedRef.current = true;
+			setIsDownloading(false);
+
+			setActiveProvider("huggingface")
+				.then(() => {
+					if (router.canGoBack()) {
+						router.back();
+					} else {
+						router.replace("/dashboard");
+					}
+				})
+				.catch(() => {
+					router.replace("/dashboard");
+				});
+		}
+	}, [downloadedAt, router, setActiveProvider]);
+
+	const handlePause = async () => {
+		try {
+			const { pauseDownload } = await import(
+				"@/src/ai-providers/huggingface/download"
+			);
+			await pauseDownload(store);
+			setIsDownloading(false);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to pause");
+		}
+	};
+
+	const handleResume = async () => {
+		setIsDownloading(true);
+		setError(undefined);
+		try {
+			const { resumeDownload } = await import(
+				"@/src/ai-providers/huggingface/download"
+			);
+			await resumeDownload(store);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to resume");
+			setIsDownloading(false);
+		}
+	};
+
+	const handleRestart = async () => {
+		setIsDownloading(true);
+		setError(undefined);
+		try {
+			const { startDownload } = await import(
+				"@/src/ai-providers/huggingface/download"
+			);
+			await startDownload(store, true);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Download failed");
+			setIsDownloading(false);
+		}
+	};
+
+	return (
+		<View style={{ flex: 1 }}>
+			<GradientBackground variant="simple" />
+
+			<SafeAreaView style={{ flex: 1 }}>
+				<View
+					style={{
+						width: "100%",
+						justifyContent: "space-between",
+						alignItems: "center",
+						flexDirection: "row",
+						padding: 16,
+					}}
+				>
+					{/* Hide back button while downloading */}
+					<View style={{ width: 40 }} />
+					<View style={{ marginLeft: "auto" }}>
+						<ModeToggle />
+					</View>
+				</View>
+
+				<View
+					style={{
+						flex: 1,
+						justifyContent: "center",
+						alignItems: "center",
+						paddingHorizontal: 24,
+						maxWidth: 400,
+						alignSelf: "center",
+						width: "100%",
+					}}
+				>
+					<View style={{ alignItems: "center", marginBottom: 40 }}>
+						<Text
+							variant="title"
+							style={{ textAlign: "center", marginBottom: 16, fontSize: 32 }}
+						>
+							Download AI Model
+						</Text>
+						<Text
+							variant="body"
+							style={{
+								textAlign: "center",
+								lineHeight: 24,
+								opacity: 0.8,
+								maxWidth: 256,
+								margin: "auto",
+							}}
+						>
+							{hasPartialDownload
+								? isPaused
+									? "Resume or restart your paused download"
+									: "Download in progress, please don't leave this screen"
+								: "Get started by downloading your selected AI model for private, on-device conversations."}
+						</Text>
+						{displayName && fileSizeGB && (
+							<Text
+								variant="body"
+								style={{
+									textAlign: "center",
+									marginTop: 16,
+									fontSize: 14,
+									opacity: 0.6,
+								}}
+							>
+								{displayName} ({fileSizeGB} GB)
+							</Text>
+						)}
+					</View>
+				</View>
+
+				<View
+					style={{
+						width: "100%",
+						paddingHorizontal: 24,
+						paddingBottom: 40,
+						gap: 12,
+						minHeight: 300,
+						display: "flex",
+						justifyContent: "flex-end",
+					}}
+				>
+					<View style={{ width: "100%", gap: 16, paddingVertical: 24 }}>
+						{hasPartialDownload && (
+							<View style={{ gap: 8, paddingHorizontal: 24 }}>
+								<View
+									style={{
+										flexDirection: "row",
+										justifyContent: "space-between",
+										alignItems: "center",
+									}}
+								>
+									<Text style={{ fontSize: 14 }}>
+										{downloading ? "Downloading..." : "Paused"}
+									</Text>
+									<Text style={{ fontSize: 14, fontWeight: "600" }}>
+										{progressSizeGB?.toFixed(2) || 0} GB /{" "}
+										{totalSizeGB?.toFixed(2) || 0} GB (
+										{Math.round(progressValue * 100)}%)
+									</Text>
+								</View>
+								<Progress value={progressValue} height={12} />
+							</View>
+						)}
+
+						{error && (
+							<View
+								style={{
+									padding: 12,
+									backgroundColor: "rgba(239, 68, 68, 0.1)",
+									borderRadius: 8,
+									borderWidth: 1,
+									borderColor: "rgba(239, 68, 68, 0.3)",
+								}}
+							>
+								<Text style={{ color: "#ef4444", fontSize: 14 }}>{error}</Text>
+							</View>
+						)}
+
+						<Text
+							style={{
+								fontSize: 12,
+								textAlign: "center",
+								maxWidth: 220,
+								marginHorizontal: "auto",
+							}}
+						>
+							The download may take a while, you can pause and resume at any
+							time.
+						</Text>
+					</View>
+
+					{downloading && (
+						<Button
+							onPress={() => setShowGame(true)}
+							style={{ width: "100%" }}
+						>
+							Play a game while you wait
+						</Button>
+					)}
+
+					{hasPartialDownload ? (
+						<>
+							{downloading ? (
+								<Button
+									onPress={handlePause}
+									variant="outline"
+									style={{ width: "100%" }}
+								>
+									Pause Download
+								</Button>
+							) : (
+								<Button onPress={handleResume} style={{ width: "100%" }}>
+									{`Resume Download (${Number.parseFloat(
+										(progressValue * 100).toString(),
+									).toFixed(1)}%)`}
+								</Button>
+							)}
+
+							{!downloading && (
+								<Button
+									variant="outline"
+									onPress={handleRestart}
+									disabled={isDownloading}
+									style={{ width: "100%" }}
+								>
+									Restart Download
+								</Button>
+							)}
+						</>
+					) : null}
+				</View>
+			</SafeAreaView>
+
+			<Modal
+				visible={showGame}
+				animationType="slide"
+				presentationStyle="pageSheet"
+				onRequestClose={() => setShowGame(false)}
+			>
+				<View style={{ flex: 1, backgroundColor }}>
+					<FlappyBird onClose={() => setShowGame(false)} />
+				</View>
+			</Modal>
+		</View>
+	);
+}

--- a/components/provider-setup/HuggingFaceSetup.tsx
+++ b/components/provider-setup/HuggingFaceSetup.tsx
@@ -44,7 +44,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import type { Store } from "tinybase";
-import { useCell, useRowIds } from "tinybase/ui-react";
+import { useCell, useTable } from "tinybase/ui-react";
 
 interface DisplayModel {
 	id: string; // hfModels row ID format: repoId__filename
@@ -117,8 +117,10 @@ function formatBytesGB(bytes: number): string {
 
 export function HuggingFaceSetup({
 	initialSearch,
+	onboarding = false,
 }: {
 	initialSearch?: string;
+	onboarding?: boolean;
 } = {}) {
 	const router = useRouter();
 	const { setActiveProvider } = useAIProvider();
@@ -144,13 +146,13 @@ export function HuggingFaceSetup({
 	const [rateLimitCountdown, setRateLimitCountdown] = useState(0);
 	const [isOffline, setIsOffline] = useState(false);
 	const [freeDiskSpace, setFreeDiskSpace] = useState<number | null>(null);
-	const searchTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+	const searchTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
 	// Advanced section state
 	const [advancedExpanded, setAdvancedExpanded] = useState(false);
 	const [hfToken, setHfToken] = useState("");
 	const [isTokenLoaded, setIsTokenLoaded] = useState(false);
-	const tokenSaveTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+	const tokenSaveTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
 	// Check available disk space
 	useEffect(() => {
@@ -260,23 +262,22 @@ export function HuggingFaceSetup({
 	}, [providerStatus, setActiveProvider]);
 
 	// Subscribed to hfModels table for downloaded models
-	const downloadedModelIds = useRowIds("hfModels");
+	// useTable reacts to all cell changes (including downloadedAt being set),
+	// unlike useRowIds which only fires when rows are added/removed.
+	const hfModelsTable = useTable("hfModels");
 
 	const downloadedModels = useMemo(() => {
-		return downloadedModelIds
-			.map((id) => {
-				const row = store.getRow("hfModels", id);
-				return {
-					id,
-					displayName: (row?.displayName as string) || id,
-					fileSizeBytes: (row?.fileSizeBytes as number) || 0,
-					quantization: (row?.quantization as string) || "",
-					pipelineTag: (row?.pipelineTag as string) || "",
-					downloadedAt: (row?.downloadedAt as string) || "",
-				};
-			})
-			.filter((m) => m.downloadedAt);
-	}, [downloadedModelIds, store]);
+		return Object.entries(hfModelsTable)
+			.filter(([, row]) => !!row.downloadedAt)
+			.map(([id, row]) => ({
+				id,
+				displayName: (row.displayName as string) || id,
+				fileSizeBytes: (row.fileSizeBytes as number) || 0,
+				quantization: (row.quantization as string) || "",
+				pipelineTag: (row.pipelineTag as string) || "",
+				downloadedAt: (row.downloadedAt as string) || "",
+			}));
+	}, [hfModelsTable]);
 
 	const featuredModels = useMemo(
 		() => FEATURED_MODELS.map(featuredToDisplay),
@@ -443,6 +444,14 @@ export function HuggingFaceSetup({
 				(store.getCell("hfModels", rowId, "localFilename") as string) ?? "",
 			);
 
+			// During onboarding, navigate to dedicated download screen
+			if (onboarding) {
+				router.push(
+					`/provider-setup/huggingface-download?modelId=${encodeURIComponent(rowId)}`,
+				);
+				return;
+			}
+
 			// Start download via provider
 			try {
 				const { createHuggingFaceProvider } = await import(
@@ -454,7 +463,7 @@ export function HuggingFaceSetup({
 				setError(err instanceof Error ? err.message : "Download failed");
 			}
 		},
-		[store],
+		[store, onboarding, router],
 	);
 
 	const handleDownloadModel = useCallback(
@@ -524,7 +533,7 @@ export function HuggingFaceSetup({
 									"@/src/ai-providers/huggingface/provider"
 								);
 								const provider = createHuggingFaceProvider(store);
-								await provider.deleteModel(modelId);
+								await provider.deleteModel?.(modelId);
 								// Refresh free disk space after deletion
 								getFreeDiskStorageAsync()
 									.then((bytes) => setFreeDiskSpace(bytes))


### PR DESCRIPTION
Fixes two Hugging Face pain points: a stale-state bug on the provider screen and a cluttered onboarding flow.

**Bug fix:**
- The HF setup screen was not reflecting newly downloaded models until a re-render, even though the chat dropdown showed the correct state. This was a state sync issue.

**Onboarding improvement:**
- During onboarding, the HF flow now only allows one model download at a time with a dedicated downloading screen (matching the Whisper AI provider flow). The existing Settings flow where users can download additional models is unchanged.

