### PR TITLE
feat: caching of LLM models when running app within emulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ coverage/
 # bundled whisper model (too large for git, ~150MB)
 assets/models/*.bin
 modules/**/android/build
+
+# caching proxy
+.cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Thanks for your interest in contributing to Whisper! We welcome contributions fr
 1. Fork the repository
 2. Clone your fork locally
 3. Install dependencies with `npm install`
-4. Run the app with `npm run ios` or `npm run android`
+4. Run the app with `npm run ios` or `npm run android` (see **Caching model downloads on emulators** below when running on an emulator)
 
 ## How to Contribute
 
@@ -47,6 +47,17 @@ Browse our open issues. If you find an unassigned issue you'd like to work on, c
 - Keep PRs focused on a single issue
 - Follow existing code patterns and conventions
 - Run `npm run lint` before submitting
+
+### Caching model downloads on emulators
+
+When working on model-download code, emulators re-fetch multi-gigabyte GGUF files on every fresh install. To avoid this, run the local caching proxy in a separate terminal:
+
+```bash
+npm run caching         # start proxy on http://localhost:8787
+npm run caching:clear   # wipe the .cache/ directory
+```
+
+`src/utils/dev-proxy.ts` automatically routes downloads through the proxy on emulators in dev mode; physical devices and production builds bypass it entirely.
 
 ## Community & Questions
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,8 @@ module.exports = {
 	coverageDirectory: "coverage",
 	coverageReporters: ["text", "lcov", "html"],
 	testMatch: ["**/__tests__/**/*.test.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)"],
+	testPathIgnorePatterns: ["/node_modules/", "/.claude/worktrees/"],
+	modulePathIgnorePatterns: ["<rootDir>/.claude/worktrees/"],
 	setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
 	moduleNameMapper: {
 		"^@/(.*)$": "<rootDir>/$1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
 		"process-icons": "npx tsx scripts/process-icons.ts",
 		"semgrep": "semgrep scan --config auto",
 		"audit": "npm audit",
-		"knip": "knip --no-config-hints"
+		"knip": "knip --no-config-hints",
+		"caching": "npx tsx scripts/caching-proxy.ts",
+		"caching:clear": "npx tsx scripts/clear-cache.ts"
 	},
 	"dependencies": {
 		"@ai-sdk/anthropic": "^3.0.50",

--- a/scripts/caching-proxy.ts
+++ b/scripts/caching-proxy.ts
@@ -1,0 +1,379 @@
+/**
+ * Local caching HTTP proxy for development on emulators/simulators.
+ *
+ * Emulators re-download large GGUF model files on every fresh install, which
+ * is slow and wastes bandwidth. This proxy sits in front of HuggingFace (and
+ * any other model host) and caches responses to `.cache/` keyed by URL.
+ *
+ * The app routes downloads through this proxy in dev mode only, via
+ * `src/utils/dev-proxy.ts`'s `maybeProxyUrl()`. Physical devices and
+ * production builds bypass the proxy entirely.
+ *
+ * Usage:
+ *   npm run caching           # start the proxy (foreground)
+ *   npm run caching:clear     # wipe the cache directory
+ *
+ * Request shape:
+ *   GET http://localhost:8787/proxy?url=<encoded upstream URL>
+ *
+ * Features:
+ *   - Streams cache writes to disk (no buffering huge files in memory)
+ *   - Forwards Authorization header to upstream (gated HF models)
+ *   - Follows redirects (HF returns 302 to cdn-lfs.hf.co)
+ *   - Serves Range requests from cache (resumable downloads)
+ *   - Atomic writes via `.partial` + rename
+ */
+
+import { createHash } from "node:crypto";
+import {
+	createReadStream,
+	createWriteStream,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { rename } from "node:fs/promises";
+import {
+	createServer,
+	type IncomingMessage,
+	type ServerResponse,
+} from "node:http";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { ReadableStream as WebReadableStream } from "node:stream/web";
+
+const PORT = 8787;
+const CACHE_DIR = join(process.cwd(), ".cache");
+
+if (!existsSync(CACHE_DIR)) {
+	mkdirSync(CACHE_DIR, { recursive: true });
+}
+
+// Track URLs currently being fetched so we don't try to cache them twice.
+const inFlight = new Set<string>();
+
+interface CacheMeta {
+	url: string;
+	contentType: string;
+	contentLength: string | null;
+	savedAt: string;
+}
+
+function keyForUrl(url: string): string {
+	return createHash("sha256").update(url).digest("hex");
+}
+
+function cachePathForKey(key: string): string {
+	return join(CACHE_DIR, key);
+}
+
+function metaPathForKey(key: string): string {
+	return join(CACHE_DIR, `${key}.meta.json`);
+}
+
+function formatBytes(bytes: number): string {
+	if (!bytes) return "0 B";
+	const gb = bytes / 1024 ** 3;
+	if (gb >= 1) return `${gb.toFixed(2)} GB`;
+	const mb = bytes / 1024 ** 2;
+	if (mb >= 1) return `${mb.toFixed(2)} MB`;
+	const kb = bytes / 1024;
+	return `${kb.toFixed(2)} KB`;
+}
+
+function parseRangeHeader(
+	header: string | undefined,
+	fileSize: number,
+): { start: number; end: number } | null {
+	if (!header) return null;
+	const match = /bytes=(\d*)-(\d*)/.exec(header);
+	if (!match) return null;
+	const start = match[1] ? Number.parseInt(match[1], 10) : 0;
+	const end = match[2] ? Number.parseInt(match[2], 10) : fileSize - 1;
+	if (
+		Number.isNaN(start) ||
+		Number.isNaN(end) ||
+		start > end ||
+		start >= fileSize
+	) {
+		return null;
+	}
+	return { start, end: Math.min(end, fileSize - 1) };
+}
+
+function readMeta(metaPath: string): CacheMeta | null {
+	try {
+		return JSON.parse(readFileSync(metaPath, "utf8")) as CacheMeta;
+	} catch {
+		return null;
+	}
+}
+
+async function serveFromCache(
+	req: IncomingMessage,
+	res: ServerResponse,
+	cachePath: string,
+	metaPath: string,
+): Promise<void> {
+	const meta = readMeta(metaPath);
+	const stat = statSync(cachePath);
+	const size = stat.size;
+	const contentType = meta?.contentType || "application/octet-stream";
+
+	const range = parseRangeHeader(req.headers.range, size);
+	if (range) {
+		const { start, end } = range;
+		const chunkSize = end - start + 1;
+		res.writeHead(206, {
+			"Content-Range": `bytes ${start}-${end}/${size}`,
+			"Accept-Ranges": "bytes",
+			"Content-Length": String(chunkSize),
+			"Content-Type": contentType,
+		});
+		await pipeline(createReadStream(cachePath, { start, end }), res);
+		return;
+	}
+
+	res.writeHead(200, {
+		"Content-Length": String(size),
+		"Accept-Ranges": "bytes",
+		"Content-Type": contentType,
+	});
+	await pipeline(createReadStream(cachePath), res);
+}
+
+async function fetchAndMaybeCache(
+	req: IncomingMessage,
+	res: ServerResponse,
+	upstreamUrl: string,
+	cachePath: string,
+	metaPath: string,
+): Promise<void> {
+	const key = keyForUrl(upstreamUrl);
+
+	// Only cache complete downloads (no Range header) and only one at a time
+	// per URL. Range requests and concurrent fetches are passed through.
+	const canCache = !req.headers.range && !inFlight.has(key);
+
+	// Forward a minimal set of headers to the upstream. We explicitly ask for
+	// `identity` encoding so Node's fetch doesn't auto-decompress a body whose
+	// content-length header we're about to pass through (that mismatch would
+	// truncate the response on the client side).
+	const forwardHeaders: Record<string, string> = {
+		"accept-encoding": "identity",
+	};
+	if (req.headers.authorization) {
+		forwardHeaders.authorization = req.headers.authorization as string;
+	}
+	if (req.headers.range) {
+		forwardHeaders.range = req.headers.range as string;
+	}
+
+	const rangeLabel = req.headers.range ? ` (range: ${req.headers.range})` : "";
+	console.info(`[cache] FETCH ${upstreamUrl}${rangeLabel}`);
+
+	const upstreamRes = await fetch(upstreamUrl, {
+		headers: forwardHeaders,
+		redirect: "follow",
+	});
+
+	if (!upstreamRes.ok && upstreamRes.status !== 206) {
+		res.writeHead(upstreamRes.status, { "Content-Type": "text/plain" });
+		res.end(
+			`Upstream error: ${upstreamRes.status} ${upstreamRes.statusText}\n`,
+		);
+		return;
+	}
+
+	const contentLength = upstreamRes.headers.get("content-length");
+	const contentType =
+		upstreamRes.headers.get("content-type") || "application/octet-stream";
+	const contentRange = upstreamRes.headers.get("content-range");
+
+	const respHeaders: Record<string, string> = {
+		"Content-Type": contentType,
+		"Accept-Ranges": "bytes",
+	};
+	if (contentLength) respHeaders["Content-Length"] = contentLength;
+	if (contentRange) respHeaders["Content-Range"] = contentRange;
+	res.writeHead(upstreamRes.status, respHeaders);
+
+	if (!upstreamRes.body) {
+		res.end();
+		return;
+	}
+
+	const nodeStream = Readable.fromWeb(
+		upstreamRes.body as unknown as WebReadableStream<Uint8Array>,
+	);
+
+	if (!canCache) {
+		await pipeline(nodeStream, res);
+		return;
+	}
+
+	inFlight.add(key);
+	const partialPath = `${cachePath}.partial`;
+	const diskStream = createWriteStream(partialPath);
+
+	// Capture disk errors asynchronously so we can surface them from the pump.
+	let diskError: Error | null = null;
+	diskStream.on("error", (err) => {
+		diskError = err;
+	});
+
+	try {
+		// Manual tee: pump chunks from upstream to both the response and the
+		// on-disk partial. The two sinks have independent lifecycles — if the
+		// client disconnects mid-download we still finish writing the cache,
+		// and if the disk write fails we still try to satisfy the client.
+		for await (const chunk of nodeStream) {
+			if (diskError) throw diskError;
+
+			if (!diskStream.write(chunk)) {
+				await new Promise<void>((resolve, reject) => {
+					const onDrain = () => {
+						diskStream.off("error", onError);
+						resolve();
+					};
+					const onError = (err: Error) => {
+						diskStream.off("drain", onDrain);
+						reject(err);
+					};
+					diskStream.once("drain", onDrain);
+					diskStream.once("error", onError);
+				});
+			}
+
+			if (!res.closed && !res.errored) {
+				if (!res.write(chunk)) {
+					await new Promise<void>((resolve) => {
+						const done = () => {
+							res.off("drain", done);
+							res.off("close", done);
+							resolve();
+						};
+						res.once("drain", done);
+						res.once("close", done);
+					});
+				}
+			}
+		}
+
+		// Close the response first (client-facing path); the disk write is
+		// finalized separately so its completion isn't tied to the client.
+		if (!res.writableEnded) res.end();
+
+		await new Promise<void>((resolve, reject) => {
+			diskStream.end(() => {
+				if (diskError) reject(diskError);
+				else resolve();
+			});
+		});
+
+		// Promote the partial file to the canonical cache entry.
+		await rename(partialPath, cachePath);
+		const savedBytes = statSync(cachePath).size;
+		const meta: CacheMeta = {
+			url: upstreamUrl,
+			contentType,
+			contentLength: contentLength ?? String(savedBytes),
+			savedAt: new Date().toISOString(),
+		};
+		writeFileSync(metaPath, JSON.stringify(meta, null, 2));
+		console.info(
+			`[cache] SAVED ${formatBytes(savedBytes)} ${upstreamUrl}`,
+		);
+	} catch (err) {
+		console.error("[cache] download failed, discarding partial:", err);
+		diskStream.destroy();
+		try {
+			unlinkSync(partialPath);
+		} catch {
+			// ignore
+		}
+		if (!res.writableEnded) {
+			try {
+				res.end();
+			} catch {
+				// ignore
+			}
+		}
+	} finally {
+		inFlight.delete(key);
+	}
+}
+
+async function handleRequest(
+	req: IncomingMessage,
+	res: ServerResponse,
+): Promise<void> {
+	const url = new URL(req.url ?? "/", `http://localhost:${PORT}`);
+
+	if (url.pathname === "/") {
+		res.writeHead(200, { "Content-Type": "text/plain" });
+		res.end(
+			"whisper caching proxy\nUsage: GET /proxy?url=<encoded upstream URL>\n",
+		);
+		return;
+	}
+
+	if (url.pathname !== "/proxy") {
+		res.writeHead(404, { "Content-Type": "text/plain" });
+		res.end("Not found. Use /proxy?url=<upstream>\n");
+		return;
+	}
+
+	const upstreamUrl = url.searchParams.get("url");
+	if (!upstreamUrl) {
+		res.writeHead(400, { "Content-Type": "text/plain" });
+		res.end("Missing 'url' query param\n");
+		return;
+	}
+
+	const key = keyForUrl(upstreamUrl);
+	const cachePath = cachePathForKey(key);
+	const metaPath = metaPathForKey(key);
+
+	try {
+		if (existsSync(cachePath)) {
+			const rangeLabel = req.headers.range
+				? ` (range: ${req.headers.range})`
+				: "";
+			console.info(`[cache] HIT  ${upstreamUrl}${rangeLabel}`);
+			await serveFromCache(req, res, cachePath, metaPath);
+			return;
+		}
+		console.info(`[cache] MISS ${upstreamUrl}`);
+		await fetchAndMaybeCache(req, res, upstreamUrl, cachePath, metaPath);
+	} catch (err) {
+		console.error("[cache] error handling request:", err);
+		if (!res.headersSent) {
+			res.writeHead(500, { "Content-Type": "text/plain" });
+			res.end(`Proxy error: ${String(err)}\n`);
+		} else {
+			res.destroy();
+		}
+	}
+}
+
+const server = createServer((req, res) => {
+	handleRequest(req, res).catch((err) => {
+		console.error("[cache] unhandled:", err);
+	});
+});
+
+server.listen(PORT, () => {
+	console.info(`[cache] Caching proxy listening on http://localhost:${PORT}`);
+	console.info(`[cache] Cache dir: ${CACHE_DIR}`);
+	console.info("[cache] Ctrl-C to stop");
+});
+
+process.on("SIGINT", () => {
+	console.info("\n[cache] shutting down");
+	server.close(() => process.exit(0));
+});

--- a/scripts/clear-cache.ts
+++ b/scripts/clear-cache.ts
@@ -1,0 +1,45 @@
+/**
+ * Wipes the local development caching proxy's cache directory.
+ *
+ * Pairs with `scripts/caching-proxy.ts`. Use this when you want to force a
+ * fresh download on the next emulator run, or when cached responses have
+ * become stale.
+ */
+
+import { existsSync, rmSync, statSync } from "node:fs";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const CACHE_DIR = join(process.cwd(), ".cache");
+
+function formatBytes(bytes: number): string {
+	if (!bytes) return "0 B";
+	const gb = bytes / 1024 ** 3;
+	if (gb >= 1) return `${gb.toFixed(2)} GB`;
+	const mb = bytes / 1024 ** 2;
+	if (mb >= 1) return `${mb.toFixed(2)} MB`;
+	const kb = bytes / 1024;
+	return `${kb.toFixed(2)} KB`;
+}
+
+function directorySize(dir: string): number {
+	let total = 0;
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			total += directorySize(full);
+		} else {
+			total += statSync(full).size;
+		}
+	}
+	return total;
+}
+
+if (!existsSync(CACHE_DIR)) {
+	console.info(`[cache] nothing to clear: ${CACHE_DIR} does not exist`);
+	process.exit(0);
+}
+
+const sizeBefore = directorySize(CACHE_DIR);
+rmSync(CACHE_DIR, { recursive: true, force: true });
+console.info(`[cache] cleared ${formatBytes(sizeBefore)} from ${CACHE_DIR}`);

--- a/src/__tests__/ai-providers/huggingface/download.test.ts
+++ b/src/__tests__/ai-providers/huggingface/download.test.ts
@@ -39,6 +39,10 @@ jest.mock("../../../utils/bytes", () => ({
 	bytesToGB: jest.fn((bytes: number) => bytes / (1024 * 1024 * 1024)),
 }));
 
+jest.mock("../../../utils/dev-proxy", () => ({
+	maybeProxyUrl: (url: string) => url,
+}));
+
 const mockGetCredential = jest.fn();
 
 jest.mock("../../../actions/secure-credentials", () => ({

--- a/src/ai-providers/huggingface/download.ts
+++ b/src/ai-providers/huggingface/download.ts
@@ -5,6 +5,7 @@ import {
 } from "expo-file-system/legacy";
 import type { Store } from "tinybase";
 import { bytesToGB } from "../../utils/bytes";
+import { maybeProxyUrl } from "../../utils/dev-proxy";
 import { getCredential } from "../../actions/secure-credentials";
 
 const PROVIDER_ID = "huggingface";
@@ -201,7 +202,7 @@ async function downloadMmproj(store: Store, modelId: string): Promise<void> {
 	try {
 		const downloadOptions = await getDownloadOptions();
 		const resumable = createDownloadResumable(
-			mmprojDownloadUrl,
+			maybeProxyUrl(mmprojDownloadUrl),
 			fileUri,
 			downloadOptions,
 			createProgressCallback(store),
@@ -462,7 +463,7 @@ export async function startDownload(
 	try {
 		console.info(`[HuggingFace:Download] Starting download: ${localFilename}`);
 		const resumable = createDownloadResumable(
-			downloadUrl,
+			maybeProxyUrl(downloadUrl),
 			fileUri,
 			downloadOptions,
 			createProgressCallback(store),

--- a/src/ai-providers/whisper-ai/download.ts
+++ b/src/ai-providers/whisper-ai/download.ts
@@ -6,6 +6,7 @@ import {
 import type { Store } from "tinybase";
 import type { WhisperLLMCard } from "whisper-llm-cards";
 import { bytesToGB } from "../../utils/bytes";
+import { maybeProxyUrl } from "../../utils/dev-proxy";
 import { generateModelFileName } from "../../utils/generate-model-filename";
 
 // Module-scoped download reference
@@ -156,7 +157,7 @@ async function downloadMmproj(
 
 	try {
 		const resumable = createDownloadResumable(
-			card.multimodal.mmproj.sourceUrl,
+			maybeProxyUrl(card.multimodal.mmproj.sourceUrl),
 			fileUri,
 			{},
 			createProgressCallback(store),
@@ -379,7 +380,7 @@ export async function startDownload(
 	try {
 		console.info(`[WhisperAI:Download] Starting download to ${versionedFilename}`);
 		const resumable = createDownloadResumable(
-			sourceUrl,
+			maybeProxyUrl(sourceUrl),
 			fileUri,
 			{},
 			createProgressCallback(store),

--- a/src/data/generated-authors.json
+++ b/src/data/generated-authors.json
@@ -99,16 +99,6 @@
       "section": "libraries"
     },
     {
-      "author": "Felix Boehm",
-      "description": "Creator of htmlparser2",
-      "packages": [
-        "htmlparser2"
-      ],
-      "url": "https://github.com/fb55/htmlparser2",
-      "priority": 50,
-      "section": "libraries"
-    },
-    {
       "author": "Gowtham G",
       "description": "Creator of react-native-marked",
       "packages": [
@@ -313,16 +303,6 @@
           "react-native-gifted-chat"
         ],
         "url": "https://github.com/FaridSafi/react-native-gifted-chat#readme",
-        "priority": 50,
-        "section": "libraries"
-      },
-      {
-        "author": "Felix Boehm",
-        "description": "Creator of htmlparser2",
-        "packages": [
-          "htmlparser2"
-        ],
-        "url": "https://github.com/fb55/htmlparser2",
         "priority": 50,
         "section": "libraries"
       },

--- a/src/utils/dev-proxy.ts
+++ b/src/utils/dev-proxy.ts
@@ -1,0 +1,15 @@
+import * as Device from "expo-device";
+import { Platform } from "react-native";
+
+const DEV_PROXY_PORT = 8787;
+
+/**
+ * In dev mode on emulators/simulators, routes the URL through a local
+ * caching proxy to avoid re-downloading large model files.
+ * On physical devices and in production the URL is returned unchanged.
+ */
+export function maybeProxyUrl(url: string): string {
+	if (!__DEV__ || Device.isDevice) return url;
+	const host = Platform.OS === "android" ? "10.0.2.2" : "localhost";
+	return `http://${host}:${DEV_PROXY_PORT}/proxy?url=${encodeURIComponent(url)}`;
+}


### PR DESCRIPTION
# Local caching proxy for model downloads on emulators

## Why

Testing locally from start to end often results in re-download multi-GB GGUF model files, which is slow and wastes real and mental bandwidth during development.

## What

- `scripts/caching-proxy.ts` - local HTTP proxy on port 8787 that caches upstream responses to `.cache/` keyed by URL hash. Supports Range requests, forwards `Authorization` headers (gated HF models), and follows redirects.
- `scripts/clear-cache.ts` - wipes the cache directory.
- `src/utils/dev-proxy.ts` - `maybeProxyUrl()` routes downloads through the proxy only when `__DEV__ && !Device.isDevice`. Physical devices and production builds bypass it entirely.
- HuggingFace and Whisper-AI downloaders now call `maybeProxyUrl()` on their source URLs.
- `.gitignore` ignores `.cache/`.
- `CONTRIBUTING.md` documents the two npm scripts.

## Usage

```bash
npm run caching         # start proxy (separate terminal)
npm run caching:clear   # wipe the cache
```
