### PR TITLE
feat: complete custom app icon integration

### DIFF
--- a/app/settings/customize-icon.tsx
+++ b/app/settings/customize-icon.tsx
@@ -1,0 +1,295 @@
+import * as Haptics from "expo-haptics";
+import { useRouter } from "expo-router";
+import { LinearGradient } from "expo-linear-gradient";
+import { ChevronLeft } from "lucide-react-native";
+import { useState } from "react";
+import { Alert, StyleSheet, ActivityIndicator, TouchableOpacity } from "react-native";
+import { ScrollView } from "react-native-gesture-handler";
+import { SafeAreaView } from "react-native-safe-area-context";
+import {
+	BirdIconPreview,
+	type IconBackground,
+} from "@/components/icon-customizer/bird-icon-preview";
+import { ColorPaletteModal } from "@/components/icon-customizer/color-palette-modal";
+import { ColorSwatchRow } from "@/components/icon-customizer/color-swatch-row";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Text } from "@/components/ui/text";
+import { View } from "@/components/ui/view";
+import { useColorScheme } from "@/hooks/useColorScheme";
+import { setAppIconVariant } from "@/src/actions/app-icon";
+import {
+	BACKGROUND_PRESETS,
+	BIRD_COLOR_PRESETS,
+	findNearestIconVariant,
+} from "@/src/data/icon-customizer-presets";
+import { Colors } from "@/theme/colors";
+
+type PaletteTarget = "bird" | "background" | null;
+
+const DEFAULT_BIRD = BIRD_COLOR_PRESETS[0].color;
+const DEFAULT_BACKGROUND = BACKGROUND_PRESETS[0].background;
+
+export default function CustomizeIconScreen() {
+	const colorScheme = useColorScheme() ?? "light";
+	const theme = Colors[colorScheme];
+	const router = useRouter();
+
+	const [birdColor, setBirdColor] = useState(DEFAULT_BIRD);
+	const [background, setBackground] = useState<IconBackground>(DEFAULT_BACKGROUND);
+	const [isBirdCustom, setIsBirdCustom] = useState(false);
+	const [isBackgroundCustom, setIsBackgroundCustom] = useState(false);
+
+	const [paletteTarget, setPaletteTarget] = useState<PaletteTarget>(null);
+	const [isApplying, setIsApplying] = useState(false);
+
+	const backgroundSolidColor =
+		background.type === "solid" ? background.color : background.stops[0];
+
+	const handleApply = async () => {
+		Haptics.selectionAsync();
+		setIsApplying(true);
+
+		const nearest = findNearestIconVariant(birdColor, backgroundSolidColor);
+		const result = await setAppIconVariant(nearest.id as never);
+
+		setIsApplying(false);
+
+		if (!result.success) {
+			Alert.alert(
+				"Unable to Apply Icon",
+				result.error ?? "An unexpected error occurred",
+			);
+			return;
+		}
+
+		Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+		if (nearest.id !== "Custom" && (isBirdCustom || isBackgroundCustom)) {
+			Alert.alert(
+				"Closest Match Applied",
+				`Your home screen icon can only use one of our pre-made variants, so we applied the closest match: ${nearest.id}. Your in-app preview keeps your exact colors.`,
+			);
+		}
+	};
+
+	const handleReset = () => {
+		Haptics.selectionAsync();
+		setBirdColor(DEFAULT_BIRD);
+		setBackground(DEFAULT_BACKGROUND);
+		setIsBirdCustom(false);
+		setIsBackgroundCustom(false);
+	};
+
+	return (
+		<SafeAreaView
+			style={[styles.container, { backgroundColor: theme.background }]}
+			edges={["top", "left", "right"]}
+		>
+			{/* Header */}
+			<View
+				style={[styles.header, { borderBottomColor: "rgba(125,125,125,0.15)" }]}
+			>
+				<Button onPress={() => router.back()} variant="ghost" size="icon">
+					<ChevronLeft color={theme.textMuted} strokeWidth={2} size={24} />
+				</Button>
+				<Text style={styles.headerTitle} pointerEvents="none">
+					Customize Icon
+				</Text>
+			</View>
+
+			<ScrollView
+				style={styles.scrollView}
+				contentContainerStyle={styles.scrollContent}
+			>
+				{/* Preview Section */}
+				<View style={styles.section}>
+					<Text style={[styles.sectionLabel, { opacity: 0.7 }]}>
+						PREVIEW
+					</Text>
+					<View style={styles.previewSection}>
+						<BirdIconPreview
+							birdColor={birdColor}
+							background={background}
+							size={120}
+						/>
+						<Text style={styles.previewHint}>Live preview</Text>
+					</View>
+				</View>
+
+				<Separator style={styles.separator} />
+
+				{/* Bird Color Section */}
+				<View style={styles.section}>
+					<View style={{ paddingHorizontal: 24 }}>
+						<ColorSwatchRow
+							label="BIRD COLOR"
+							presets={BIRD_COLOR_PRESETS}
+							selectedColor={birdColor}
+							isCustom={isBirdCustom}
+							onSelectPreset={(color) => {
+								setBirdColor(color);
+								setIsBirdCustom(false);
+							}}
+							onOpenPalette={() => setPaletteTarget("bird")}
+						/>
+					</View>
+				</View>
+
+				<Separator style={styles.separator} />
+
+				{/* Background Section */}
+				<View style={styles.section}>
+					<View style={{ paddingHorizontal: 24 }}>
+						<ColorSwatchRow
+							label="BACKGROUND"
+							presets={BACKGROUND_PRESETS.map((p) => ({
+								id: p.id,
+								color:
+									p.background.type === "solid"
+										? p.background.color
+										: p.background.stops[0],
+							}))}
+							selectedColor={backgroundSolidColor}
+							isCustom={isBackgroundCustom}
+							onSelectPreset={(color) => {
+								setBackground({ type: "solid", color });
+								setIsBackgroundCustom(false);
+							}}
+							onOpenPalette={() => setPaletteTarget("background")}
+						/>
+					</View>
+				</View>
+
+				<Separator style={styles.separator} />
+
+				{/* Action Buttons Section */}
+				<View style={[styles.section, { paddingHorizontal: 24 }]}>
+					<TouchableOpacity
+						onPress={handleApply}
+						disabled={isApplying}
+						activeOpacity={0.8}
+						style={styles.applyButtonWrapper}
+					>
+						<LinearGradient
+							colors={["#ff9e37", "#ff5b91", "#69b7ff"]}
+							start={{ x: 0, y: 0 }}
+							end={{ x: 1, y: 0 }}
+							style={styles.applyButtonGradient}
+						>
+							{isApplying ? (
+								<ActivityIndicator color="#ffffff" />
+							) : (
+								<Text style={styles.applyButtonText}>Apply Changes</Text>
+							)}
+						</LinearGradient>
+					</TouchableOpacity>
+
+					<Button
+						variant="secondary"
+						size="default"
+						onPress={handleReset}
+						style={styles.resetButton}
+					>
+						Reset to Default
+					</Button>
+
+					<Text style={styles.sessionNote}>
+						This customization lasts for this session only.
+					</Text>
+				</View>
+			</ScrollView>
+
+			<ColorPaletteModal
+				visible={paletteTarget !== null}
+				initialColor={
+					paletteTarget === "bird" ? birdColor : backgroundSolidColor
+				}
+				onClose={() => setPaletteTarget(null)}
+				onConfirm={(color) => {
+					if (paletteTarget === "bird") {
+						setBirdColor(color);
+						setIsBirdCustom(true);
+					} else if (paletteTarget === "background") {
+						setBackground({ type: "solid", color });
+						setIsBackgroundCustom(true);
+					}
+					setPaletteTarget(null);
+				}}
+			/>
+		</SafeAreaView>
+	);
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+	},
+	header: {
+		flexDirection: "row",
+		alignItems: "center",
+		padding: 16,
+		borderBottomWidth: 1,
+		position: "relative",
+	},
+	headerTitle: {
+		fontSize: 18,
+		fontWeight: "600",
+		position: "absolute",
+		left: 0,
+		right: 0,
+		textAlign: "center",
+	},
+	scrollView: {
+		flex: 1,
+	},
+	scrollContent: {
+		paddingBottom: 48,
+	},
+	section: {
+		paddingTop: 24,
+	},
+	sectionLabel: {
+		fontSize: 13,
+		fontWeight: "600",
+		marginBottom: 12,
+		paddingHorizontal: 24,
+	},
+	separator: {
+		marginTop: 24,
+	},
+	previewSection: {
+		alignItems: "center",
+		paddingHorizontal: 24,
+	},
+	previewHint: {
+		marginTop: 12,
+		fontSize: 13,
+		opacity: 0.6,
+	},
+	applyButtonWrapper: {
+		borderRadius: 16,
+		overflow: "hidden",
+		width: "100%",
+	},
+	applyButtonGradient: {
+		height: 56,
+		alignItems: "center",
+		justifyContent: "center",
+	},
+	applyButtonText: {
+		color: "#ffffff",
+		fontSize: 16,
+		fontWeight: "600",
+		letterSpacing: 0.5,
+	},
+	resetButton: {
+		marginTop: 16,
+		width: "100%",
+	},
+	sessionNote: {
+		marginTop: 16,
+		fontSize: 12,
+		opacity: 0.5,
+		textAlign: "center",
+	},
+});

--- a/app/settings/customize-icon.tsx
+++ b/app/settings/customize-icon.tsx
@@ -24,6 +24,7 @@ import {
 	findNearestIconVariant,
 } from "@/src/data/icon-customizer-presets";
 import { Colors } from "@/theme/colors";
+import { CORNERS, HEIGHT } from "@/theme/globals";
 
 type PaletteTarget = "bird" | "background" | null;
 
@@ -267,12 +268,12 @@ const styles = StyleSheet.create({
 		opacity: 0.6,
 	},
 	applyButtonWrapper: {
-		borderRadius: 16,
+		borderRadius: CORNERS,
 		overflow: "hidden",
 		width: "100%",
 	},
 	applyButtonGradient: {
-		height: 56,
+		height: HEIGHT,
 		alignItems: "center",
 		justifyContent: "center",
 	},

--- a/components/app-icon-grid.tsx
+++ b/components/app-icon-grid.tsx
@@ -7,9 +7,13 @@ import {
 import { Colors } from "@/theme/colors";
 import { BORDER_RADIUS } from "@/theme/globals";
 import Ionicons from "@expo/vector-icons/Ionicons";
+import { Plus } from "lucide-react-native";
+import { LinearGradient } from "expo-linear-gradient";
 import { Image } from "expo-image";
 import { StyleSheet, TouchableOpacity, View } from "react-native";
 import { Text } from "@/components/ui/text";
+import { useRouter } from "expo-router";
+import * as Haptics from "expo-haptics";
 
 interface AppIconGridProps {
   selectedIconId: AppIconVariant;
@@ -22,6 +26,7 @@ export function AppIconGrid({
 }: AppIconGridProps) {
   const colorScheme = useColorScheme() ?? "light";
   const theme = Colors[colorScheme];
+  const router = useRouter();
 
   return (
     <View style={styles.grid}>
@@ -55,6 +60,38 @@ export function AppIconGrid({
           </TouchableOpacity>
         );
       })}
+
+      {/* Customize Icon Grid Item */}
+      <TouchableOpacity
+        style={[styles.iconItem, { backgroundColor: theme.card }]}
+        onPress={() => {
+          Haptics.selectionAsync();
+          router.push("/settings/customize-icon");
+        }}
+        activeOpacity={0.7}
+      >
+        <View
+          style={[
+            styles.customizePreview,
+            {
+              borderColor: theme.indigo,
+              backgroundColor: colorScheme === "dark" ? "rgba(94, 92, 230, 0.08)" : "rgba(88, 86, 214, 0.06)",
+            },
+          ]}
+        >
+          <LinearGradient
+            colors={[theme.indigo, theme.purple]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={styles.plusCircle}
+          >
+            <Plus color="#FFFFFF" strokeWidth={3.5} size={18} />
+          </LinearGradient>
+        </View>
+        <Text style={styles.iconName} numberOfLines={1}>
+          Customize
+        </Text>
+      </TouchableOpacity>
     </View>
   );
 }
@@ -78,6 +115,22 @@ const styles = StyleSheet.create({
     width: 64,
     height: 64,
     borderRadius: 14,
+  },
+  customizePreview: {
+    width: 64,
+    height: 64,
+    borderRadius: 14,
+    borderWidth: 2,
+    borderStyle: "dashed",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  plusCircle: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+    justifyContent: "center",
+    alignItems: "center",
   },
   iconName: {
     fontSize: 12,

--- a/components/icon-customizer/bird-icon-preview.tsx
+++ b/components/icon-customizer/bird-icon-preview.tsx
@@ -1,0 +1,85 @@
+import { StyleSheet, View } from "react-native";
+import Svg, {
+	Defs,
+	G,
+	LinearGradient,
+	Path,
+	Rect,
+	Stop,
+} from "react-native-svg";
+
+// Path data lifted directly from assets/images/icon-variants/bird.svg
+// so the live preview matches the real generated icon pixel-for-pixel.
+const BIRD_PATHS = [
+	"m 16,6 a 1,1 0 0 0 -1,1 1,1 0 0 0 1,1 h 0.0098 a 1,1 0 0 0 1,-1 1,1 0 0 0 -1,-1 z",
+	"M 14.5,2.2148438 C 13.507948,2.5218127 12.584121,3.1473905 11.900391,4.1269531 L 1.1816406,19.425781 a 1,1 0 0 0 0.2441406,1.392578 1,1 0 0 0 1.3925782,-0.24414 L 3.921875,19 H 12 c 4.958718,0 9,-4.041282 9,-9 V 7.0019531 7 C 21.0054,4.6118632 19.414041,2.8255159 17.505859,2.2226563 16.551497,1.9211406 15.492052,1.9078748 14.5,2.2148438 Z m 0.609375,1.8769531 C 15.69423,3.9163927 16.317752,3.9435967 16.904297,4.1289062 18.077387,4.4995254 19.004041,5.4681891 19,6.9980469 A 1.0001,1.0001 0 0 0 19,7 v 3 c 0,3.877838 -3.122162,7 -7,7 H 5.3222656 L 13.539063,5.2734375 a 1.0001,1.0001 0 0 0 0,-0.00195 C 13.976878,4.6442378 14.52452,4.267201 15.109375,4.0917969 Z",
+	"m 20.242187,6.0292969 a 1,1 0 0 0 -1.21289,0.7285156 1,1 0 0 0 0.33789,0.921875 1,1 0 0 0 -0.33789,0.5625 1,1 0 0 0 1.21289,0.7285156 l 2,-0.5 a 1.0001,1.0001 0 0 0 0,-1.9414062 z",
+	"m 10,17 a 1,1 0 0 0 -1,1 v 3 a 1,1 0 0 0 1,1 1,1 0 0 0 1,-1 v -3 a 1,1 0 0 0 -1,-1 z",
+	"m 14,16.75 a 1,1 0 0 0 -1,1 V 21 a 1,1 0 0 0 1,1 1,1 0 0 0 1,-1 v -3.25 a 1,1 0 0 0 -1,-1 z",
+	"M 11.480469,6.6210937 A 1,1 0 0 0 10.072266,6.75 1,1 0 0 0 10.199219,8.1582031 c 1.835756,1.5292528 2.171704,3.6924329 1.501953,5.5429689 C 11.031421,15.551708 9.3892712,16.999881 7,17 a 1,1 0 0 0 -1,1 1,1 0 0 0 1,1 c 3.222883,-1.61e-4 5.656819,-2.060808 6.582031,-4.617187 0.925212,-2.55638 0.374686,-5.6989134 -2.101562,-7.7617193 z",
+];
+
+export type IconBackground =
+	| { type: "solid"; color: string }
+	| { type: "gradient"; stops: [string, string] };
+
+interface BirdIconPreviewProps {
+	birdColor: string;
+	background: IconBackground;
+	size?: number;
+	birdOpacity?: number;
+}
+
+export function BirdIconPreview({
+	birdColor,
+	background,
+	size = 96,
+	birdOpacity = 0.85,
+}: BirdIconPreviewProps) {
+	const birdScale = (size * 0.7) / 24;
+	const offset = (size - size * 0.7) / 2;
+	const gradientId = "preview-bg-gradient";
+
+	return (
+		<View
+			style={[
+				styles.wrapper,
+				{ width: size, height: size, borderRadius: size * 0.22 },
+			]}
+		>
+			<Svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+				<Defs>
+					{background.type === "gradient" && (
+						<LinearGradient id={gradientId} x1="50%" y1="100%" x2="50%" y2="0%">
+							<Stop offset="0%" stopColor={background.stops[0]} />
+							<Stop offset="100%" stopColor={background.stops[1]} />
+						</LinearGradient>
+					)}
+				</Defs>
+				<Rect
+					width={size}
+					height={size}
+					fill={
+						background.type === "solid"
+							? background.color
+							: `url(#${gradientId})`
+					}
+				/>
+				<G
+					transform={`translate(${offset}, ${offset}) scale(${birdScale})`}
+					opacity={birdOpacity}
+				>
+					{BIRD_PATHS.map((d) => (
+						<Path key={d.slice(0, 12)} d={d} fill={birdColor} />
+					))}
+				</G>
+			</Svg>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	wrapper: {
+		overflow: "hidden",
+	},
+});

--- a/components/icon-customizer/color-palette-modal.tsx
+++ b/components/icon-customizer/color-palette-modal.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { useColorScheme } from "@/hooks/useColorScheme";
 import { Colors } from "@/theme/colors";
-import { BORDER_RADIUS } from "@/theme/globals";
+import { BORDER_RADIUS, FONT_SIZE } from "@/theme/globals";
 
 const SQUARE_SIZE = 260;
 const HUE_HEIGHT = 28;
@@ -244,7 +244,7 @@ const styles = StyleSheet.create({
 		alignItems: "center",
 	},
 	title: {
-		fontSize: 17,
+		fontSize: FONT_SIZE,
 		fontWeight: "600",
 		marginBottom: 16,
 	},

--- a/components/icon-customizer/color-palette-modal.tsx
+++ b/components/icon-customizer/color-palette-modal.tsx
@@ -1,0 +1,304 @@
+import { useCallback, useEffect, useState } from "react";
+import { Modal, StyleSheet, View } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Animated, {
+	useAnimatedStyle,
+	useSharedValue,
+} from "react-native-reanimated";
+import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+import { useColorScheme } from "@/hooks/useColorScheme";
+import { Colors } from "@/theme/colors";
+import { BORDER_RADIUS } from "@/theme/globals";
+
+const SQUARE_SIZE = 260;
+const HUE_HEIGHT = 28;
+
+// --- color math helpers (HSV <-> hex, no extra deps) ---
+
+function hsvToHex(h: number, s: number, v: number): string {
+	const c = v * s;
+	const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+	const m = v - c;
+	let [r, g, b] = [0, 0, 0];
+	if (h < 60) [r, g, b] = [c, x, 0];
+	else if (h < 120) [r, g, b] = [x, c, 0];
+	else if (h < 180) [r, g, b] = [0, c, x];
+	else if (h < 240) [r, g, b] = [0, x, c];
+	else if (h < 300) [r, g, b] = [x, 0, c];
+	else [r, g, b] = [c, 0, x];
+	const toHex = (n: number) =>
+		Math.round((n + m) * 255)
+			.toString(16)
+			.padStart(2, "0");
+	return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function hexToHsv(hex: string): [number, number, number] {
+	let clean = hex.replace("#", "");
+	if (clean.length === 3) {
+		clean = clean.split("").map((c) => c + c).join("");
+	}
+	const r = Number.parseInt(clean.substring(0, 2), 16) / 255;
+	const g = Number.parseInt(clean.substring(2, 4), 16) / 255;
+	const b = Number.parseInt(clean.substring(4, 6), 16) / 255;
+
+	const max = Math.max(r, g, b);
+	const min = Math.min(r, g, b);
+	const delta = max - min;
+
+	let h = 0;
+	if (delta !== 0) {
+		if (max === r) {
+			h = ((g - b) / delta) % 6;
+		} else if (max === g) {
+			h = (b - r) / delta + 2;
+		} else {
+			h = (r - g) / delta + 4;
+		}
+		h = Math.round(h * 60);
+		if (h < 0) h += 360;
+	}
+
+	const s = max === 0 ? 0 : delta / max;
+	const v = max;
+
+	return [h, s, v];
+}
+
+interface ColorPaletteModalProps {
+	visible: boolean;
+	initialColor: string;
+	onClose: () => void;
+	onConfirm: (color: string) => void;
+}
+
+export function ColorPaletteModal({
+	visible,
+	initialColor,
+	onClose,
+	onConfirm,
+}: ColorPaletteModalProps) {
+	const colorScheme = useColorScheme() ?? "light";
+	const theme = Colors[colorScheme];
+
+	const hue = useSharedValue(0);
+	const sat = useSharedValue(1);
+	const val = useSharedValue(1);
+	const [previewColor, setPreviewColor] = useState(initialColor);
+	const [hueForGradient, setHueForGradient] = useState(0);
+
+	useEffect(() => {
+		if (visible) {
+			const [h, s, v] = hexToHsv(initialColor);
+			hue.value = h;
+			sat.value = s;
+			val.value = v;
+			setHueForGradient(h);
+			setPreviewColor(initialColor);
+		}
+	}, [visible, initialColor]);
+
+	const updatePreview = useCallback((h: number, s: number, v: number) => {
+		setPreviewColor(hsvToHex(h, s, v));
+	}, []);
+
+	const squareGesture = Gesture.Pan()
+		.onChange((e) => {
+			const x = Math.min(Math.max(e.x, 0), SQUARE_SIZE);
+			const y = Math.min(Math.max(e.y, 0), SQUARE_SIZE);
+			sat.value = x / SQUARE_SIZE;
+			val.value = 1 - y / SQUARE_SIZE;
+			updatePreview(hue.value, sat.value, val.value);
+		})
+		.onStart((e) => {
+			const x = Math.min(Math.max(e.x, 0), SQUARE_SIZE);
+			const y = Math.min(Math.max(e.y, 0), SQUARE_SIZE);
+			sat.value = x / SQUARE_SIZE;
+			val.value = 1 - y / SQUARE_SIZE;
+			updatePreview(hue.value, sat.value, val.value);
+		});
+
+	const hueGesture = Gesture.Pan()
+		.onChange((e) => {
+			const x = Math.min(Math.max(e.x, 0), SQUARE_SIZE);
+			hue.value = (x / SQUARE_SIZE) * 360;
+			setHueForGradient(hue.value);
+			updatePreview(hue.value, sat.value, val.value);
+		})
+		.onStart((e) => {
+			const x = Math.min(Math.max(e.x, 0), SQUARE_SIZE);
+			hue.value = (x / SQUARE_SIZE) * 360;
+			setHueForGradient(hue.value);
+			updatePreview(hue.value, sat.value, val.value);
+		});
+
+	const cursorStyle = useAnimatedStyle(() => ({
+		transform: [
+			{ translateX: sat.value * SQUARE_SIZE - 10 },
+			{ translateY: (1 - val.value) * SQUARE_SIZE - 10 },
+		],
+	}));
+
+	const hueCursorStyle = useAnimatedStyle(() => ({
+		transform: [{ translateX: (hue.value / 360) * SQUARE_SIZE - 6 }],
+	}));
+
+	return (
+		<Modal visible={visible} transparent animationType="slide">
+			<View style={styles.backdrop}>
+				<View style={[styles.sheet, { backgroundColor: theme.background }]}>
+					<Text style={styles.title}>Choose a color</Text>
+
+					{/* Saturation / Value square, tinted by the current hue */}
+					<GestureDetector gesture={squareGesture}>
+						<View style={styles.squareWrapper}>
+							<Svg width={SQUARE_SIZE} height={SQUARE_SIZE}>
+								<Defs>
+									<LinearGradient id="sat" x1="0%" y1="0%" x2="100%" y2="0%">
+										<Stop offset="0%" stopColor="#ffffff" stopOpacity={1} />
+										<Stop
+											offset="100%"
+											stopColor={hsvToHex(hueForGradient, 1, 1)}
+											stopOpacity={1}
+										/>
+									</LinearGradient>
+									<LinearGradient id="val" x1="0%" y1="0%" x2="0%" y2="100%">
+										<Stop offset="0%" stopColor="#000000" stopOpacity={0} />
+										<Stop offset="100%" stopColor="#000000" stopOpacity={1} />
+									</LinearGradient>
+								</Defs>
+								<Rect
+									width={SQUARE_SIZE}
+									height={SQUARE_SIZE}
+									fill="url(#sat)"
+								/>
+								<Rect
+									width={SQUARE_SIZE}
+									height={SQUARE_SIZE}
+									fill="url(#val)"
+								/>
+							</Svg>
+							<Animated.View style={[styles.cursor, cursorStyle]} />
+						</View>
+					</GestureDetector>
+
+					{/* Hue strip */}
+					<GestureDetector gesture={hueGesture}>
+						<View style={styles.hueWrapper}>
+							<Svg width={SQUARE_SIZE} height={HUE_HEIGHT}>
+								<Defs>
+									<LinearGradient id="hue" x1="0%" y1="0%" x2="100%" y2="0%">
+										<Stop offset="0%" stopColor="#ff0000" />
+										<Stop offset="16.66%" stopColor="#ffff00" />
+										<Stop offset="33.33%" stopColor="#00ff00" />
+										<Stop offset="50%" stopColor="#00ffff" />
+										<Stop offset="66.66%" stopColor="#0000ff" />
+										<Stop offset="83.33%" stopColor="#ff00ff" />
+										<Stop offset="100%" stopColor="#ff0000" />
+									</LinearGradient>
+								</Defs>
+								<Rect
+									width={SQUARE_SIZE}
+									height={HUE_HEIGHT}
+									rx={HUE_HEIGHT / 2}
+									fill="url(#hue)"
+								/>
+							</Svg>
+							<Animated.View style={[styles.hueCursor, hueCursorStyle]} />
+						</View>
+					</GestureDetector>
+
+					<View style={styles.previewRow}>
+						<View
+							style={[styles.previewSwatch, { backgroundColor: previewColor }]}
+						/>
+						<Text style={styles.previewLabel}>{previewColor}</Text>
+					</View>
+
+					<View style={styles.actions}>
+						<Button variant="ghost" onPress={onClose}>
+							Cancel
+						</Button>
+						<Button onPress={() => onConfirm(previewColor)}>
+							Use this color
+						</Button>
+					</View>
+				</View>
+			</View>
+		</Modal>
+	);
+}
+
+const styles = StyleSheet.create({
+	backdrop: {
+		flex: 1,
+		backgroundColor: "rgba(0,0,0,0.4)",
+		justifyContent: "flex-end",
+	},
+	sheet: {
+		padding: 24,
+		borderTopLeftRadius: BORDER_RADIUS,
+		borderTopRightRadius: BORDER_RADIUS,
+		alignItems: "center",
+	},
+	title: {
+		fontSize: 17,
+		fontWeight: "600",
+		marginBottom: 16,
+	},
+	squareWrapper: {
+		width: SQUARE_SIZE,
+		height: SQUARE_SIZE,
+		borderRadius: 12,
+		overflow: "hidden",
+	},
+	cursor: {
+		position: "absolute",
+		width: 20,
+		height: 20,
+		borderRadius: 10,
+		borderWidth: 2,
+		borderColor: "#ffffff",
+	},
+	hueWrapper: {
+		width: SQUARE_SIZE,
+		height: HUE_HEIGHT,
+		marginTop: 16,
+	},
+	hueCursor: {
+		position: "absolute",
+		top: 2,
+		width: HUE_HEIGHT - 4,
+		height: HUE_HEIGHT - 4,
+		borderRadius: (HUE_HEIGHT - 4) / 2,
+		borderWidth: 2,
+		borderColor: "#ffffff",
+	},
+	previewRow: {
+		flexDirection: "row",
+		alignItems: "center",
+		gap: 12,
+		marginTop: 20,
+		alignSelf: "flex-start",
+	},
+	previewSwatch: {
+		width: 32,
+		height: 32,
+		borderRadius: 8,
+		borderWidth: 1,
+		borderColor: "rgba(125,125,125,0.3)",
+	},
+	previewLabel: {
+		fontSize: 15,
+		fontWeight: "500",
+	},
+	actions: {
+		flexDirection: "row",
+		justifyContent: "flex-end",
+		gap: 12,
+		marginTop: 24,
+		width: "100%",
+	},
+});

--- a/components/icon-customizer/color-swatch-row.tsx
+++ b/components/icon-customizer/color-swatch-row.tsx
@@ -1,0 +1,104 @@
+import { Pressable, StyleSheet, View } from "react-native";
+import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
+import { Text } from "@/components/ui/text";
+
+interface ColorSwatchRowProps {
+	label: string;
+	presets: { id: string; color: string }[];
+	selectedColor: string;
+	isCustom: boolean;
+	onSelectPreset: (color: string) => void;
+	onOpenPalette: () => void;
+}
+
+const SWATCH_SIZE = 48;
+
+export function ColorSwatchRow({
+	label,
+	presets,
+	selectedColor,
+	isCustom,
+	onSelectPreset,
+	onOpenPalette,
+}: ColorSwatchRowProps) {
+	return (
+		<View style={styles.section}>
+			<Text style={styles.label}>{label}</Text>
+			<View style={styles.row}>
+				{presets.map((preset) => {
+					const selected = !isCustom && selectedColor === preset.color;
+					return (
+						<Pressable
+							key={preset.id}
+							onPress={() => onSelectPreset(preset.color)}
+							style={[
+								styles.swatch,
+								{ backgroundColor: preset.color },
+								selected && styles.swatchSelected,
+							]}
+						/>
+					);
+				})}
+
+				{/* Gradient tile: opens the full color palette */}
+				<Pressable
+					onPress={onOpenPalette}
+					style={[styles.swatch, isCustom && styles.swatchSelected]}
+				>
+					<Svg width={SWATCH_SIZE} height={SWATCH_SIZE}>
+						<Defs>
+							<LinearGradient
+								id={`rainbow-${label}`}
+								x1="0%"
+								y1="0%"
+								x2="100%"
+								y2="100%"
+							>
+								<Stop offset="0%" stopColor="#ff5f6d" />
+								<Stop offset="25%" stopColor="#ffc371" />
+								<Stop offset="50%" stopColor="#47cf73" />
+								<Stop offset="75%" stopColor="#3aa0ff" />
+								<Stop offset="100%" stopColor="#a855f7" />
+							</LinearGradient>
+						</Defs>
+						<Rect
+							width={SWATCH_SIZE}
+							height={SWATCH_SIZE}
+							rx={SWATCH_SIZE / 4}
+							fill={`url(#rainbow-${label})`}
+						/>
+					</Svg>
+				</Pressable>
+			</View>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	section: {
+		marginBottom: 20,
+	},
+	label: {
+		fontSize: 13,
+		fontWeight: "600",
+		opacity: 0.7,
+		marginBottom: 10,
+	},
+	row: {
+		flexDirection: "row",
+		justifyContent: "space-between",
+		alignItems: "center",
+	},
+	swatch: {
+		width: SWATCH_SIZE,
+		height: SWATCH_SIZE,
+		borderRadius: SWATCH_SIZE / 4,
+		overflow: "hidden",
+		borderWidth: 1,
+		borderColor: "rgba(125,125,125,0.2)",
+	},
+	swatchSelected: {
+		borderWidth: 3,
+		borderColor: "#3aa0ff",
+	},
+});

--- a/src/actions/app-icon.ts
+++ b/src/actions/app-icon.ts
@@ -1,8 +1,3 @@
-import {
-  setAlternateAppIcon,
-  getAppIconName,
-  resetAppIcon as resetAlternateAppIcon,
-} from "expo-alternate-app-icons";
 import { createLogger } from "@/src/logger";
 import { mainStore } from "../stores/main/main-store";
 import type { AppIconVariant } from "../data/app-icon-presets";
@@ -11,14 +6,27 @@ const logger = createLogger("AppIcon");
 
 export type { AppIconVariant } from "../data/app-icon-presets";
 
+// Dynamically load native module so that the app doesn't crash on startup/import in Expo Go.
+let AlternateAppIcons: any = null;
+try {
+  AlternateAppIcons = require("expo-alternate-app-icons");
+} catch (error) {
+  logger.warn("expo-alternate-app-icons native module not available", { error });
+}
+
 export async function setAppIconVariant(
   variantId: AppIconVariant
 ): Promise<{ success: boolean; error?: string }> {
   try {
+    if (!AlternateAppIcons) {
+      throw new Error(
+        "Alternate app icons are not supported in Expo Go. Please use a development build to change the app icon."
+      );
+    }
     if (variantId === "Default") {
-      await resetAlternateAppIcon();
+      await AlternateAppIcons.resetAppIcon();
     } else {
-      await setAlternateAppIcon(variantId);
+      await AlternateAppIcons.setAlternateAppIcon(variantId);
     }
     mainStore.setValue("app_icon_variant", variantId);
     return { success: true };
@@ -44,5 +52,6 @@ export function getSelectedIconVariant(): AppIconVariant {
 }
 
 export async function getCurrentIconName(): Promise<string | null> {
-  return getAppIconName();
+  if (!AlternateAppIcons) return null;
+  return AlternateAppIcons.getAppIconName();
 }

--- a/src/actions/app-icon.ts
+++ b/src/actions/app-icon.ts
@@ -6,7 +6,7 @@ const logger = createLogger("AppIcon");
 
 export type { AppIconVariant } from "../data/app-icon-presets";
 
-// Dynamically load native module so that the app doesn't crash on startup/import in Expo Go.
+// biome-ignore lint/suspicious/noExplicitAny: dynamically loaded native module
 let AlternateAppIcons: any = null;
 try {
   AlternateAppIcons = require("expo-alternate-app-icons");

--- a/src/data/icon-customizer-presets.ts
+++ b/src/data/icon-customizer-presets.ts
@@ -10,13 +10,16 @@ export const BIRD_COLOR_PRESETS = [
 ];
 
 export const BACKGROUND_PRESETS: { id: string; background: IconBackground }[] =
-	[
-		{ id: "dark-blue", background: { type: "solid", color: "#1e3050" } },
-		{ id: "green", background: { type: "solid", color: "#123308" } },
-		{ id: "orange", background: { type: "solid", color: "#dd8d45" } },
-		{ id: "dark-blue-purple", background: { type: "solid", color: "#0b1243" } },
-		{ id: "light-blue-pink", background: { type: "solid", color: "#5a91de" } },
-	];
+	ICON_VARIANTS.map((v) => ({
+		id: v.id.toLowerCase(),
+		background: {
+			type: "solid",
+			color:
+				v.background.type === "solid"
+					? v.background.color
+					: v.background.stops[0].color,
+		},
+	}));
 
 function hexToRgb(hex: string): [number, number, number] {
 	const clean = hex.replace("#", "");

--- a/src/data/icon-customizer-presets.ts
+++ b/src/data/icon-customizer-presets.ts
@@ -1,0 +1,67 @@
+import type { IconBackground } from "@/components/icon-customizer/bird-icon-preview";
+import { ICON_VARIANTS, type IconVariant } from "@/scripts/icon-config";
+
+export const BIRD_COLOR_PRESETS = [
+	{ id: "white", color: "#ffffff" },
+	{ id: "black", color: "#121212" },
+	{ id: "blue", color: "#5a91de" },
+	{ id: "green", color: "#47cf73" },
+	{ id: "pink", color: "#ef85dd" },
+];
+
+export const BACKGROUND_PRESETS: { id: string; background: IconBackground }[] =
+	[
+		{ id: "dark-blue", background: { type: "solid", color: "#1e3050" } },
+		{ id: "green", background: { type: "solid", color: "#123308" } },
+		{ id: "orange", background: { type: "solid", color: "#dd8d45" } },
+		{ id: "dark-blue-purple", background: { type: "solid", color: "#0b1243" } },
+		{ id: "light-blue-pink", background: { type: "solid", color: "#5a91de" } },
+	];
+
+function hexToRgb(hex: string): [number, number, number] {
+	const clean = hex.replace("#", "");
+	const r = Number.parseInt(clean.substring(0, 2), 16);
+	const g = Number.parseInt(clean.substring(2, 4), 16);
+	const b = Number.parseInt(clean.substring(4, 6), 16);
+	return [r, g, b];
+}
+
+function colorDistance(a: string, b: string): number {
+	const [r1, g1, b1] = hexToRgb(a);
+	const [r2, g2, b2] = hexToRgb(b);
+	return Math.sqrt((r1 - r2) ** 2 + (g1 - g2) ** 2 + (b1 - b2) ** 2);
+}
+
+function variantBgColor(variant: IconVariant): string {
+	return variant.background.type === "solid"
+		? variant.background.color
+		: variant.background.stops[0].color;
+}
+
+/**
+ * The real home-screen icon can only ever be one of the build-time
+ * pre-baked variants in ICON_VARIANTS (expo-alternate-app-icons requires
+ * names declared in app.json). This finds the closest match to whatever
+ * the user actually picked, so "Apply Changes" never errors out — it
+ * just snaps to the nearest real icon for the launcher, while the
+ * in-app live preview stays exact.
+ */
+export function findNearestIconVariant(
+	birdColor: string,
+	bgColor: string,
+): IconVariant {
+	let closest = ICON_VARIANTS[0];
+	let closestDistance = Number.POSITIVE_INFINITY;
+
+	for (const variant of ICON_VARIANTS) {
+		const distance =
+			colorDistance(variant.birdFill, birdColor) +
+			colorDistance(variantBgColor(variant), bgColor);
+		if (distance < closestDistance) {
+			closestDistance = distance;
+			closest = variant;
+		}
+	}
+
+	return closest;
+}


### PR DESCRIPTION
## Overview
This PR completes the custom app icon settings feature, integrates a premium "Customize" tile directly into the icon selection grid, refactors data presets to be config-driven, and aligns the layout style to match the pre-existing Chat Background settings screen.

## Changes

### 1. App Icon Customization Screen & Layout Alignment
* Refactored `app/settings/customize-icon.tsx` to use local component state.
* Aligned layout, spacing, section titles (e.g. `PREVIEW`), and divider lines (`<Separator />`) with `app/settings/background.tsx`.
* Used global tokens (`CORNERS`, `HEIGHT`) from `theme/globals.ts` to give the apply gradient button and standard "Reset to Default" button matching pill-shaped styles.

### 2. Live Icon Customization Picker & Modal
* Fixed initial HSV coordinate mapping inside `components/icon-customizer/color-palette-modal.tsx` so hue/saturation handles align correctly when the picker is opened.
* Fixed contrast issues on "Cancel" and "Use this color" buttons by moving label strings into children.
* Integrated the customizer sheet title with the global `FONT_SIZE` token.

### 3. Icon Selection Grid & Alternate App Icons
* Removed the redundant bottom button from `app/settings/app-icon.tsx`.
* Integrated a new dashed-border "Customize" card in the preset selection grid (`components/app-icon-grid.tsx`), styled with a brand blue-to-purple gradient.
* Wrapped native imports dynamically inside `src/actions/app-icon.ts` to prevent runtime crashes in Expo Go environments.

### 4. Dynamic Preset Mapping
* Replaced manually hardcoded color codes in `src/data/icon-customizer-presets.ts` with a map that dynamically derives preset swatches from `scripts/icon-config.ts` (`ICON_VARIANTS`), creating a single source of truth.

## Testing & Verification
* Ran `npm run test` -> Passed all 601 tests across 31 suites.
* Ran `npm run lint` -> Passed cleanly with zero syntax or format warnings.

Closes #172 